### PR TITLE
Limit actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ These gems are:
   - [Controller Generation](#controller-generation)
     - [Command Options](#command-options-1)
       - [--attributes](#--attributes)
+      - [--controller-actions](#--controller-actions)
       - [--version-number](#--version-number)
       - [--use-paginator](#--use-paginator)
       - [--allow-filters](#--allow-filters)
@@ -509,6 +510,36 @@ class Api::V1::BlogSerializer < ActiveModel::Serializer
   attributes(
     :title,
   )
+end
+```
+
+##### `--controller-actions`
+
+Use this option if you want to choose which actions will be included in the controller.
+
+```bash
+rails g power_api:controller blog --controller-actions=show destroy
+```
+
+When you do this, you will see that only relevant code is generated in controller, tests and routes.
+
+For example, the controller would only include the `show` and `destroy` actions and wouldn't include the `blog_params` method:
+
+```ruby
+class Api::V1::BlogSerializer < Api::V1::BaseController
+  def show
+    respond_with blog
+  end
+
+  def destroy
+    respond_with blog.destroy!
+  end
+
+  private
+
+  def blog
+    @blog ||= Blog.find_by!(id: params[:id])
+  end
 end
 ```
 

--- a/lib/generators/power_api/controller/controller_generator.rb
+++ b/lib/generators/power_api/controller/controller_generator.rb
@@ -74,10 +74,12 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
 
   def add_routes
     if helper.parent_resource?
-      add_normal_route(actions: ["show", "update", "destroy"])
-      add_nested_route
+      if helper.resource_actions?
+        add_normal_route(actions: helper.controller_actions & ["show", "update", "destroy"])
+      end
+      add_nested_route if helper.collection_actions?
     else
-      add_normal_route
+      add_normal_route(actions: helper.controller_actions)
     end
 
     helper.format_ruby_file(helper.routes_path)
@@ -118,7 +120,9 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
 
   def add_nested_route
     line_to_replace = helper.parent_resource_routes_line_regex
-    nested_resource_line = helper.resource_route_tpl(actions: ['index', 'create'])
+    nested_resource_line = helper.resource_route_tpl(
+      actions: helper.controller_actions & ['index', 'create']
+    )
     add_nested_parent_route unless helper.parent_route_exist?
 
     if helper.parent_route_already_have_children?
@@ -130,9 +134,10 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
     end
   end
 
-  def add_normal_route(actions: [])
+  def add_normal_route(actions:)
+    actions_for_only_option = actions.sort == self.class.valid_actions.sort ? [] : actions
     add_route(helper.api_version_routes_line_regex) do |match|
-      "#{match}\n#{helper.resource_route_tpl(actions: actions)}"
+      "#{match}\n#{helper.resource_route_tpl(actions: actions_for_only_option)}"
     end
   end
 

--- a/lib/generators/power_api/controller/controller_generator.rb
+++ b/lib/generators/power_api/controller/controller_generator.rb
@@ -1,12 +1,23 @@
 class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('templates', __dir__)
 
+  def self.valid_actions
+    PowerApi::GeneratorHelpers::PERMITTED_ACTIONS
+  end
+
   class_option(
     :attributes,
     type: 'array',
     default: [],
     aliases: '-a',
     desc: 'attributes to show in serializer'
+  )
+
+  class_option(
+    :controller_actions,
+    type: 'array',
+    default: [],
+    desc: "actions to include in controller. Valid values: #{valid_actions.join(', ')}"
   )
 
   class_option(
@@ -145,6 +156,7 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
       parent_resource: options[:parent_resource],
       owned_by_authenticated_resource: options[:owned_by_authenticated_resource],
       resource_attributes: options[:attributes],
+      controller_actions: options[:controller_actions],
       use_paginator: options[:use_paginator],
       allow_filters: options[:allow_filters]
     )

--- a/lib/power_api/engine.rb
+++ b/lib/power_api/engine.rb
@@ -11,6 +11,7 @@ module PowerApi
 
     initializer "initialize" do
       require_relative "./errors"
+      require_relative "./generator_helper/controller_actions_helper"
       require_relative "./generator_helper/active_record_resource"
       require_relative "./generator_helper/version_helper"
       require_relative "./generator_helper/resource_helper"

--- a/lib/power_api/generator_helper/controller_actions_helper.rb
+++ b/lib/power_api/generator_helper/controller_actions_helper.rb
@@ -9,24 +9,8 @@ module PowerApi::GeneratorHelper::ControllerActionsHelper
     @controller_actions = actions.blank? ? PERMITTED_ACTIONS : actions & PERMITTED_ACTIONS
   end
 
-  def index?
-    controller_actions.include?('index')
-  end
-
-  def create?
-    controller_actions.include?('create')
-  end
-
-  def show?
-    controller_actions.include?('show')
-  end
-
-  def update?
-    controller_actions.include?('update')
-  end
-
-  def destroy?
-    controller_actions.include?('destroy')
+  PERMITTED_ACTIONS.each do |action|
+    define_method("#{action}?") { controller_actions.include?(action) }
   end
 
   def resource_actions?

--- a/lib/power_api/generator_helper/controller_actions_helper.rb
+++ b/lib/power_api/generator_helper/controller_actions_helper.rb
@@ -1,0 +1,43 @@
+module PowerApi::GeneratorHelper::ControllerActionsHelper
+  extend ActiveSupport::Concern
+
+  PERMITTED_ACTIONS = ['index', 'create', 'show', 'update', 'destroy']
+
+  attr_reader :controller_actions
+
+  def controller_actions=(actions)
+    @controller_actions = actions.blank? ? PERMITTED_ACTIONS : actions & PERMITTED_ACTIONS
+  end
+
+  def index?
+    controller_actions.include?('index')
+  end
+
+  def create?
+    controller_actions.include?('create')
+  end
+
+  def show?
+    controller_actions.include?('show')
+  end
+
+  def update?
+    controller_actions.include?('update')
+  end
+
+  def destroy?
+    controller_actions.include?('destroy')
+  end
+
+  def resource_actions?
+    show? || update? || destroy?
+  end
+
+  def collection_actions?
+    index? || create?
+  end
+
+  def update_or_create?
+    update? || create?
+  end
+end

--- a/lib/power_api/generator_helper/controller_helper.rb
+++ b/lib/power_api/generator_helper/controller_helper.rb
@@ -8,6 +8,7 @@ module PowerApi::GeneratorHelper::ControllerHelper
     include PowerApi::GeneratorHelper::PaginationHelper
     include PowerApi::GeneratorHelper::SimpleTokenAuthHelper
     include PowerApi::GeneratorHelper::TemplateBuilderHelper
+    include PowerApi::GeneratorHelper::ControllerActionsHelper
 
     attr_accessor :allow_filters
   end
@@ -73,18 +74,26 @@ fallback: :exception\n"
   end
 
   def ctrl_tpl_index
+    return unless index?
+
     concat_tpl_method("index", "respond_with #{ctrl_tpl_index_resources}")
   end
 
   def ctrl_tpl_show
+    return unless show?
+
     concat_tpl_method("show", "respond_with #{resource.snake_case}")
   end
 
   def ctrl_tpl_create
+    return unless create?
+
     concat_tpl_method("create", "respond_with #{ctrl_tpl_create_resource}")
   end
 
   def ctrl_tpl_update
+    return unless update?
+
     concat_tpl_method(
       "update",
       "respond_with #{resource.snake_case}.update!(#{resource.snake_case}_params)"
@@ -92,14 +101,20 @@ fallback: :exception\n"
   end
 
   def ctrl_tpl_destroy
+    return unless destroy?
+
     concat_tpl_method("destroy", "respond_with #{resource.snake_case}.destroy!")
   end
 
   def ctrl_tpl_resource
+    return unless resource_actions?
+
     concat_tpl_method(resource.snake_case, "@#{resource.snake_case} ||= #{ctrl_tpl_find_resource}")
   end
 
   def ctrl_tpl_permitted_params
+    return unless update_or_create?
+
     concat_tpl_method(
       "#{resource.snake_case}_params",
       "params.require(:#{resource.snake_case}).permit(",

--- a/lib/power_api/generator_helper/swagger_helper.rb
+++ b/lib/power_api/generator_helper/swagger_helper.rb
@@ -9,6 +9,7 @@ module PowerApi::GeneratorHelper::SwaggerHelper
     include PowerApi::GeneratorHelper::ResourceHelper
     include PowerApi::GeneratorHelper::SimpleTokenAuthHelper
     include PowerApi::GeneratorHelper::TemplateBuilderHelper
+    include PowerApi::GeneratorHelper::ControllerActionsHelper
   end
 
   def swagger_helper_path
@@ -201,6 +202,8 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def spec_tpl_collection_path_statements
+    return unless collection_actions?
+
     concat_tpl_statements(
       "path '/#{spec_tpl_collection_path}' do",
         spec_tpl_parent_resource_parameter,
@@ -218,6 +221,8 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def spec_tpl_resource_path_statements
+    return unless resource_actions?
+
     concat_tpl_statements(
       "path '/#{resource.plural}/{id}' do",
         spec_tpl_authenticated_resource_params,
@@ -251,6 +256,8 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def spec_tpl_index
+    return unless index?
+
     concat_tpl_statements(
       "get 'Retrieves #{resource.plural_titleized}' do",
         "description 'Retrieves all the #{resource.plural}'",
@@ -286,6 +293,8 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def spec_tpl_create
+    return unless create?
+
     concat_tpl_statements(
       "post 'Creates #{resource.titleized}' do",
         "description 'Creates #{resource.titleized}'",
@@ -320,6 +329,8 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def spec_tpl_show
+    return unless show?
+
     concat_tpl_statements(
       "get 'Retrieves #{resource.titleized}' do",
         "produces 'application/json'\n",
@@ -337,6 +348,8 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def spec_tpl_update
+    return unless update?
+
     concat_tpl_statements(
       "put 'Updates #{resource.titleized}' do",
         "description 'Updates #{resource.titleized}'",
@@ -356,6 +369,8 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def spec_tpl_destroy
+    return unless destroy?
+
     concat_tpl_statements(
       "delete 'Deletes #{resource.titleized}' do",
         "produces 'application/json'",

--- a/lib/power_api/generator_helpers.rb
+++ b/lib/power_api/generator_helpers.rb
@@ -1,5 +1,6 @@
 module PowerApi
   class GeneratorHelpers
+    include GeneratorHelper::ControllerActionsHelper
     include GeneratorHelper::ResourceHelper
     include GeneratorHelper::VersionHelper
     include GeneratorHelper::SwaggerHelper

--- a/spec/dummy/spec/lib/power_api/generator_helper/controller_actions_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/controller_actions_helper_spec.rb
@@ -1,0 +1,177 @@
+RSpec.describe PowerApi::GeneratorHelper::ControllerActionsHelper, type: :generator do
+  describe '#controller_actions=' do
+    context 'when arg is nil' do
+      before { generators_helper.controller_actions = nil }
+
+      it do
+        expect(generators_helper.controller_actions).to(
+          match_array(generators_helper.class::PERMITTED_ACTIONS)
+        )
+      end
+    end
+
+    context 'when arg is empty array' do
+      before { generators_helper.controller_actions = [] }
+
+      it do
+        expect(generators_helper.controller_actions).to(
+          match_array(generators_helper.class::PERMITTED_ACTIONS)
+        )
+      end
+    end
+
+    context 'when including not permitted actions' do
+      before { generators_helper.controller_actions = ['index', 'clone'] }
+
+      it 'ignores them' do
+        expect(generators_helper.controller_actions).to match_array(['index'])
+      end
+    end
+
+    context 'when including only permitted actions' do
+      let(:actions) { ['index', 'show'] }
+
+      before { generators_helper.controller_actions = actions }
+
+      it 'includes them all' do
+        expect(generators_helper.controller_actions).to match_array(actions)
+      end
+    end
+  end
+
+  describe 'index?' do
+    context 'when including index action' do
+      before { generators_helper.controller_actions = ['index'] }
+
+      it { expect(generators_helper.index?).to be(true) }
+    end
+
+    context 'when not including index action' do
+      before { generators_helper.controller_actions = ['show'] }
+
+      it { expect(generators_helper.index?).to be(false) }
+    end
+  end
+
+  describe 'show?' do
+    context 'when including show action' do
+      before { generators_helper.controller_actions = ['show'] }
+
+      it { expect(generators_helper.show?).to be(true) }
+    end
+
+    context 'when not including show action' do
+      before { generators_helper.controller_actions = ['index'] }
+
+      it { expect(generators_helper.show?).to be(false) }
+    end
+  end
+
+  describe 'update?' do
+    context 'when including update action' do
+      before { generators_helper.controller_actions = ['update'] }
+
+      it { expect(generators_helper.update?).to be(true) }
+    end
+
+    context 'when not including update action' do
+      before { generators_helper.controller_actions = ['show'] }
+
+      it { expect(generators_helper.update?).to be(false) }
+    end
+  end
+
+  describe 'create?' do
+    context 'when including create action' do
+      before { generators_helper.controller_actions = ['create'] }
+
+      it { expect(generators_helper.create?).to be(true) }
+    end
+
+    context 'when not including create action' do
+      before { generators_helper.controller_actions = ['show'] }
+
+      it { expect(generators_helper.create?).to be(false) }
+    end
+  end
+
+  describe 'destroy?' do
+    context 'when including destroy action' do
+      before { generators_helper.controller_actions = ['destroy'] }
+
+      it { expect(generators_helper.destroy?).to be(true) }
+    end
+
+    context 'when not including destroy action' do
+      before { generators_helper.controller_actions = ['show'] }
+
+      it { expect(generators_helper.destroy?).to be(false) }
+    end
+  end
+
+  describe 'resource_actions?' do
+    context 'when including show action' do
+      before { generators_helper.controller_actions = ['show'] }
+
+      it { expect(generators_helper.resource_actions?).to be(true) }
+    end
+
+    context 'when including update action' do
+      before { generators_helper.controller_actions = ['update'] }
+
+      it { expect(generators_helper.resource_actions?).to be(true) }
+    end
+
+    context 'when including destroy action' do
+      before { generators_helper.controller_actions = ['destroy'] }
+
+      it { expect(generators_helper.resource_actions?).to be(true) }
+    end
+
+    context 'when not including show, update or destroy actions' do
+      before { generators_helper.controller_actions = ['index', 'create'] }
+
+      it { expect(generators_helper.resource_actions?).to be(false) }
+    end
+  end
+
+  describe 'collection_actions?' do
+    context 'when including index action' do
+      before { generators_helper.controller_actions = ['index'] }
+
+      it { expect(generators_helper.collection_actions?).to be(true) }
+    end
+
+    context 'when including create action' do
+      before { generators_helper.controller_actions = ['create'] }
+
+      it { expect(generators_helper.collection_actions?).to be(true) }
+    end
+
+    context 'when not including index or create actions' do
+      before { generators_helper.controller_actions = ['show', 'update', 'destroy'] }
+
+      it { expect(generators_helper.collection_actions?).to be(false) }
+    end
+  end
+
+  describe 'update_or_create?' do
+    context 'when including update action' do
+      before { generators_helper.controller_actions = ['update'] }
+
+      it { expect(generators_helper.update_or_create?).to be(true) }
+    end
+
+    context 'when including create action' do
+      before { generators_helper.controller_actions = ['create'] }
+
+      it { expect(generators_helper.update_or_create?).to be(true) }
+    end
+
+    context 'when not including update or create actions' do
+      before { generators_helper.controller_actions = ['show', 'index', 'destroy'] }
+
+      it { expect(generators_helper.update_or_create?).to be(false) }
+    end
+  end
+end

--- a/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
@@ -112,6 +112,69 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
       it { expect(perform).to include(expected) }
     end
 
+    context 'with specific actions' do
+      let(:controller_actions) do
+        [
+          "show",
+          "update",
+          "index"
+        ]
+      end
+
+      it { expect(perform).to include("def show\n") }
+      it { expect(perform).to include("def update\n") }
+      it { expect(perform).to include("def index\n") }
+      it { expect(perform).not_to include("def destroy\n") }
+      it { expect(perform).not_to include("def create\n") }
+    end
+
+    context 'with only collection actions' do
+      let(:controller_actions) do
+        [
+          "index",
+          "create"
+        ]
+      end
+
+      it { expect(perform).not_to include("def blog\n") }
+    end
+
+    context 'with some reource actions' do
+      let(:controller_actions) do
+        [
+          "index",
+          "create",
+          "show"
+        ]
+      end
+
+      it { expect(perform).to include("def blog\n") }
+    end
+
+    context 'with update action' do
+      let(:controller_actions) { ["update"] }
+
+      it { expect(perform).to include("def blog_params\n") }
+    end
+
+    context 'with create action' do
+      let(:controller_actions) { ["create"] }
+
+      it { expect(perform).to include("def blog_params\n") }
+    end
+
+    context 'without update or create actions' do
+      let(:controller_actions) do
+        [
+          "index",
+          "destroy",
+          "show"
+        ]
+      end
+
+      it { expect(perform).not_to include("def blog_params\n") }
+    end
+
     context "with true use_paginator option" do
       let(:use_paginator) { true }
       let(:expected) do

--- a/spec/dummy/spec/lib/power_api/generator_helper/swagger_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/swagger_helper_spec.rb
@@ -421,6 +421,35 @@ RSpec.describe PowerApi::GeneratorHelper::SwaggerHelper, type: :generator do
       it { expect(perform).to include("let(:portfolio) { create(:portfolio) }") }
       it { expect(perform).to include("(:existent_blog) { create(:blog, portfolio: portfolio) }") }
     end
+
+    context 'with only some resource actions (show and update)' do
+      let(:controller_actions) do
+        [
+          "show",
+          "update"
+        ]
+      end
+
+      it { expect(perform).to include("path '/blogs/{id}' do\n") }
+      it { expect(perform).to include("get 'Retrieves Blog' do\n") }
+      it { expect(perform).to include("put 'Updates Blog' do\n") }
+      it { expect(perform).not_to include("delete 'Deletes Blog' do\n") }
+      it { expect(perform).not_to include("path '/blogs' do\n") }
+      it { expect(perform).not_to include("get 'Retrieves Blogs' do\n") }
+      it { expect(perform).not_to include("post 'Creates Blog' do\n") }
+    end
+
+    context 'with only some collection actions (index)' do
+      let(:controller_actions) { ["index"] }
+
+      it { expect(perform).not_to include("path '/blogs/{id}' do\n") }
+      it { expect(perform).not_to include("get 'Retrieves Blog' do\n") }
+      it { expect(perform).not_to include("put 'Updates Blog' do\n") }
+      it { expect(perform).not_to include("delete 'Deletes Blog' do\n") }
+      it { expect(perform).to include("path '/blogs' do\n") }
+      it { expect(perform).to include("get 'Retrieves Blogs' do\n") }
+      it { expect(perform).not_to include("post 'Creates Blog' do\n") }
+    end
   end
 
   describe "#rswag_ui_swagger_endpoint" do

--- a/spec/dummy/spec/support/test_generator_helpers.rb
+++ b/spec/dummy/spec/support/test_generator_helpers.rb
@@ -10,6 +10,7 @@ module TestGeneratorHelpers
     let(:parent_resource_name) { nil }
     let(:owned_by_authenticated_resource) { false }
     let(:resource_attributes) { nil }
+    let(:controller_actions) { [] }
     let(:use_paginator) { false }
     let(:allow_filters) { false }
 
@@ -18,6 +19,7 @@ module TestGeneratorHelpers
         version_number: version_number,
         resource: resource_name,
         resource_attributes: resource_attributes,
+        controller_actions: controller_actions,
         parent_resource: parent_resource_name,
         use_paginator: use_paginator,
         authenticated_resource: authenticated_resource,


### PR DESCRIPTION
This pr allows filtering of the actions included in the controller generator

### Changes
- Adds new class_option to controller generator: `controller_actions` (`actions` already had an alias, so it might be a reserved word or something)
- Adds new helper: `ControllerActionsHelper`. It has the logic to save the new option and exposes some boolean utility methods
- Adds guard clauses to relevant methods to limit included actions in both the `controller_helper` and the `swagger_helper`
- In `controller_generator` limits actions included in routes. Takes into account nested routes
- Adds README entry