### PR TITLE
use distinct to avoid duplicated data

### DIFF
--- a/app/controllers/concerns/api/filtered.rb
+++ b/app/controllers/concerns/api/filtered.rb
@@ -2,7 +2,7 @@ module Api::Filtered
   extend ActiveSupport::Concern
 
   def filtered_collection(collection)
-    collection.ransack(query_string_filters).result
+    collection.ransack(query_string_filters).result(distinct: true)
   end
 
   private


### PR DESCRIPTION
Avoid duplicate entries when you use multiple filters