### PR TITLE
Optional distinct added for filtered_collection to sort nested associations

### DIFF
--- a/app/controllers/concerns/api/filtered.rb
+++ b/app/controllers/concerns/api/filtered.rb
@@ -1,8 +1,8 @@
 module Api::Filtered
   extend ActiveSupport::Concern
 
-  def filtered_collection(collection)
-    collection.ransack(query_string_filters).result
+  def filtered_collection(collection, bool = true)
+    collection.ransack(query_string_filters).result(distinct: bool)
   end
 
   private


### PR DESCRIPTION
Added an optional distinct for sorting nested associations with ransack gem, since you have to set .result(distinct: false) for it to work.

For example, given an endpoint where we have many users, and each user can have many posts, and each post have a title column:

* `/users?q[s]=post_title asc`  should sort all users based on the title of their posts, but it won't work because of (distinct: true).
But if we set distinct to false, it will sort properly.

This way, when we want to sort with an association, in out controller we would do:
* `respond_with filtered_collection(User.all, false)`