### PR TITLE
Internal api

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ These gems are:
   - [Installation](#installation)
   - [Usage](#usage)
     - [Initial Setup](#initial-setup)
-    - [Public API mode](#public-api-mode)
+    - [Exposed API mode](#exposed-api-mode)
       - [Command options:](#command-options)
         - [`--authenticated-resources`](#--authenticated-resources)
     - [Internal API mode](#internal-api-mode)
-    - [Version Creation (public mode only)](#version-creation-public-mode-only)
-    - [Controller Generation (public model only)](#controller-generation-public-model-only)
+    - [Version Creation (exposed mode only)](#version-creation-exposed-mode-only)
+    - [Controller Generation (exposed model only)](#controller-generation-exposed-model-only)
       - [Command options:](#command-options-1)
         - [`--attributes`](#--attributes)
         - [`--controller-actions`](#--controller-actions)
@@ -116,14 +116,14 @@ After doing this you will get:
     We use what comes by default and kaminari as pager.
 
 After running the installer you must choose an API mode.
-### Public API mode
+### Exposed API mode
 
 Use this version if your API will be accessed by multiple clients or if your API is served somewhere other than your client application.
 
-You must run the following command to have the public API mode configuration:
+You must run the following command to have the exposed API mode configuration:
 
 ```bash
-rails generate power_api:public_api_config
+rails generate power_api:exposed_api_config
 ```
 
 After doing this you will get:
@@ -245,7 +245,7 @@ Running the above code will generate, in addition to everything described in the
 
 TODO
 
-### Version Creation (public mode only)
+### Version Creation (exposed mode only)
 
 To add a new version you must run the following command:
 ```bash
@@ -258,7 +258,7 @@ rails g power_api:version 2
 
 Doing this will add the same thing that was added for version one in the initial setup but this time for the number version provided as parameter.
 
-### Controller Generation (public model only)
+### Controller Generation (exposed model only)
 
 To add a controller you must run the following command:
 ```bash

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Running the above code will generate, in addition to everything described in the
 
 ### Internal API mode
 
-Use this mode if your API will be accessed by a web application served somewhere other than your client application.
+Use this mode if your API and your client app will be served on the same place.
 
 You must run the following command to have the internal API mode configuration:
 
@@ -253,7 +253,7 @@ rails generate power_api:internal_api_config
 
 After doing this you will get:
 
-- A base controller for the first version of your API under `/your_api/app/controllers/api/internal/base_controller.rb`
+- A base controller for your internal API under `/your_api/app/controllers/api/internal/base_controller.rb`
   ```ruby
   class Api::Internal::BaseController < Api::BaseController
     before_action do

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ These gems are:
   - [Installation](#installation)
   - [Usage](#usage)
     - [Initial Setup](#initial-setup)
+    - [Public API mode](#public-api-mode)
       - [Command options:](#command-options)
         - [`--authenticated-resources`](#--authenticated-resources)
-    - [Version Creation](#version-creation)
-    - [Controller Generation](#controller-generation)
+    - [Internal API mode](#internal-api-mode)
+    - [Version Creation (public mode only)](#version-creation-public-mode-only)
+    - [Controller Generation (public model only)](#controller-generation-public-model-only)
       - [Command options:](#command-options-1)
         - [`--attributes`](#--attributes)
         - [`--controller-actions`](#--controller-actions)
@@ -90,16 +92,6 @@ After doing this you will get:
   ```
   Here you should include everything common to all your API versions. It is usually empty because most of the configuration comes in the `PowerApi::BaseController` that is inside the gem.
 
-- A base controller for the first version of your API under `/your_api/app/controllers/api/v1/base_controller.rb`
-  ```ruby
-  class Api::V1::BaseController < Api::BaseController
-    before_action do
-      self.namespace_for_serializer = ::Api::V1
-    end
-  end
-  ```
-  Everything related to version 1 of your API must be included here.
-
 - Some initializers:
   - `/your_api/config/initializers/active_model_serializers.rb`:
     ```ruby
@@ -123,6 +115,30 @@ After doing this you will get:
     ```
     We use what comes by default and kaminari as pager.
 
+After running the installer you must choose an API mode.
+### Public API mode
+
+Use this version if your API will be accessed by multiple clients or if your API is served somewhere other than your client application.
+
+You must run the following command to have the public API mode configuration:
+
+```bash
+rails generate power_api:public_api_config
+```
+
+After doing this you will get:
+
+- A base controller for the first version of your API under `/your_api/app/controllers/api/v1/base_controller.rb`
+  ```ruby
+  class Api::V1::BaseController < Api::BaseController
+    before_action do
+      self.namespace_for_serializer = ::Api::V1
+    end
+  end
+  ```
+  Everything related to version 1 of your API must be included here.
+
+- Some initializers:
   - `/your_api/config/initializers/rswag-api.rb`:
     ```ruby
     Rswag::Api.configure do |c|
@@ -225,7 +241,11 @@ Running the above code will generate, in addition to everything described in the
   ```
 - The migration `/your_api/db/migrate/20200228173608_add_authentication_token_to_users.rb` to add the `authentication_token` to your users table.
 
-### Version Creation
+### Internal API mode
+
+TODO
+
+### Version Creation (public mode only)
 
 To add a new version you must run the following command:
 ```bash
@@ -238,7 +258,7 @@ rails g power_api:version 2
 
 Doing this will add the same thing that was added for version one in the initial setup but this time for the number version provided as parameter.
 
-### Controller Generation
+### Controller Generation (public model only)
 
 To add a controller you must run the following command:
 ```bash

--- a/bin/clean_test_app
+++ b/bin/clean_test_app
@@ -1,0 +1,2 @@
+git checkout spec/dummy/*.rb
+git status --porcelain | cut -c 3-10000000 | grep 'dummy' | xargs rm -rf

--- a/lib/generators/power_api/controller/controller_generator.rb
+++ b/lib/generators/power_api/controller/controller_generator.rb
@@ -25,7 +25,8 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
     type: 'numeric',
     default: nil,
     aliases: '-v',
-    desc: 'the API version number you want to add this controller'
+    desc: 'the API version number you want to add this controller. '\
+'Omitting this attribute will create a controller for the internal api.'
   )
 
   class_option(

--- a/lib/generators/power_api/controller/controller_generator.rb
+++ b/lib/generators/power_api/controller/controller_generator.rb
@@ -102,6 +102,13 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
     create_swagger_resource_spec
   end
 
+  def add_rspec_tests
+    return if helper.versioned_api?
+
+    create_file(helper.resource_spec_path, helper.resource_spec_tpl)
+    helper.format_ruby_file(helper.resource_spec_path)
+  end
+
   private
 
   def create_swagger_schema

--- a/lib/generators/power_api/controller/controller_generator.rb
+++ b/lib/generators/power_api/controller/controller_generator.rb
@@ -23,7 +23,7 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
   class_option(
     :version_number,
     type: 'numeric',
-    default: 1,
+    default: nil,
     aliases: '-v',
     desc: 'the API version number you want to add this controller'
   )
@@ -95,28 +95,32 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
   end
 
   def configure_swagger
-    create_file(
-      helper.swagger_resource_schema_path,
-      helper.swagger_schema_tpl
-    )
+    return unless helper.versioned_api?
 
+    create_swagger_schema
+    add_swagger_schema_to_definition
+    create_swagger_resource_spec
+  end
+
+  private
+
+  def create_swagger_schema
+    create_file(helper.swagger_resource_schema_path, helper.swagger_schema_tpl)
     helper.format_ruby_file(helper.swagger_resource_schema_path)
+  end
 
+  def add_swagger_schema_to_definition
     insert_into_file(
       helper.swagger_version_definition_path,
       helper.swagger_definition_entry,
       after: helper.swagger_definition_line_to_inject_schema
     )
-
-    create_file(
-      helper.swagger_resource_spec_path,
-      helper.swagger_resource_spec_tpl
-    )
-
-    helper.format_ruby_file(helper.swagger_resource_spec_path)
   end
 
-  private
+  def create_swagger_resource_spec
+    create_file(helper.swagger_resource_spec_path, helper.swagger_resource_spec_tpl)
+    helper.format_ruby_file(helper.swagger_resource_spec_path)
+  end
 
   def add_nested_route
     line_to_replace = helper.parent_resource_routes_line_regex

--- a/lib/generators/power_api/controller/controller_generator.rb
+++ b/lib/generators/power_api/controller/controller_generator.rb
@@ -140,13 +140,13 @@ class PowerApi::ControllerGenerator < Rails::Generators::NamedBase
 
   def add_normal_route(actions:)
     actions_for_only_option = actions.sort == self.class.valid_actions.sort ? [] : actions
-    add_route(helper.api_version_routes_line_regex) do |match|
+    add_route(helper.api_current_route_namespace_line_regex) do |match|
       "#{match}\n#{helper.resource_route_tpl(actions: actions_for_only_option)}"
     end
   end
 
   def add_nested_parent_route
-    add_route(helper.api_version_routes_line_regex) do |match|
+    add_route(helper.api_current_route_namespace_line_regex) do |match|
       "#{match}\n#{helper.resource_route_tpl(is_parent: true)}"
     end
   end

--- a/lib/generators/power_api/exposed_api_config/USAGE
+++ b/lib/generators/power_api/exposed_api_config/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Configure exposed API in host app.
+
+Example:
+    rails generate power_api:exposed_api_config

--- a/lib/generators/power_api/exposed_api_config/exposed_api_config_generator.rb
+++ b/lib/generators/power_api/exposed_api_config/exposed_api_config_generator.rb
@@ -1,4 +1,4 @@
-class PowerApi::PublicApiConfigGenerator < Rails::Generators::Base
+class PowerApi::ExposedApiConfigGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
 
   class_option(

--- a/lib/generators/power_api/install/install_generator.rb
+++ b/lib/generators/power_api/install/install_generator.rb
@@ -1,34 +1,12 @@
 class PowerApi::InstallGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
 
-  class_option(
-    :authenticated_resources,
-    type: 'array',
-    default: [],
-    desc: 'define which model or models will be token authenticatable'
-  )
-
   def create_api_base_controller
     create_file(helper.api_base_controller_path, helper.api_base_controller_tpl)
   end
 
   def create_ams_initializer
     create_file(helper.ams_initializer_path, helper.ams_initializer_tpl)
-  end
-
-  def install_rswag
-    generate "rswag:ui:install"
-    generate "rswag:api:install"
-    generate "rswag:specs:install"
-
-    create_file(helper.rswag_ui_initializer_path, helper.rswag_ui_initializer_tpl, force: true)
-    create_file(helper.swagger_helper_path, helper.swagger_helper_tpl, force: true)
-    create_file(helper.spec_swagger_path)
-    create_file(helper.spec_integration_path)
-  end
-
-  def install_first_version
-    generate "power_api:version 1"
   end
 
   def install_api_pagination
@@ -39,29 +17,9 @@ class PowerApi::InstallGenerator < Rails::Generators::Base
     )
   end
 
-  def install_simple_token_auth
-    create_file(
-      helper.simple_token_auth_initializer_path,
-      helper.simple_token_auth_initializer_tpl,
-      force: true
-    )
-
-    helper.authenticated_resources.each do |resource|
-      generate resource.authenticated_resource_migration
-
-      insert_into_file(
-        resource.path,
-        helper.simple_token_auth_method,
-        after: resource.class_definition_line
-      )
-    end
-  end
-
   private
 
   def helper
-    @helper ||= PowerApi::GeneratorHelpers.new(
-      authenticated_resources: options[:authenticated_resources]
-    )
+    @helper ||= PowerApi::GeneratorHelpers.new
   end
 end

--- a/lib/generators/power_api/install/install_generator.rb
+++ b/lib/generators/power_api/install/install_generator.rb
@@ -2,7 +2,7 @@ class PowerApi::InstallGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
 
   def create_api_base_controller
-    create_file(helper.api_base_controller_path, helper.api_base_controller_tpl)
+    create_file(helper.api_main_base_controller_path, helper.api_main_base_controller_tpl)
   end
 
   def create_ams_initializer

--- a/lib/generators/power_api/internal_api_config/USAGE
+++ b/lib/generators/power_api/internal_api_config/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Configure internal API in host app.
+
+Example:
+    rails generate power_api:internal_api_config

--- a/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
+++ b/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
@@ -1,6 +1,13 @@
 class PowerApi::InternalApiConfigGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
 
+  def add_base_controller
+    create_file(
+      helper.internal_base_controller_path,
+      helper.internal_base_controller_tpl
+    )
+  end
+
   private
 
   def helper

--- a/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
+++ b/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
@@ -1,0 +1,9 @@
+class PowerApi::InternalApiConfigGenerator < Rails::Generators::Base
+  source_root File.expand_path('templates', __dir__)
+
+  private
+
+  def helper
+    @helper ||= PowerApi::GeneratorHelpers.new
+  end
+end

--- a/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
+++ b/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
@@ -8,6 +8,10 @@ class PowerApi::InternalApiConfigGenerator < Rails::Generators::Base
     )
   end
 
+  def add_serializers_directory
+    create_file(helper.ams_serializers_path)
+  end
+
   private
 
   def helper

--- a/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
+++ b/lib/generators/power_api/internal_api_config/internal_api_config_generator.rb
@@ -8,6 +8,17 @@ class PowerApi::InternalApiConfigGenerator < Rails::Generators::Base
     )
   end
 
+  def modify_routes
+    insert_into_file(
+      helper.routes_path,
+      after: helper.routes_first_line
+    ) do
+      helper.internal_route_tpl
+    end
+
+    helper.format_ruby_file(helper.routes_path)
+  end
+
   def add_serializers_directory
     create_file(helper.ams_serializers_path)
   end

--- a/lib/generators/power_api/public_api_config/USAGE
+++ b/lib/generators/power_api/public_api_config/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Configure "public" API in host app.
+
+Example:
+    rails generate power_api:public_api_config

--- a/lib/generators/power_api/public_api_config/USAGE
+++ b/lib/generators/power_api/public_api_config/USAGE
@@ -1,5 +1,0 @@
-Description:
-    Configure "public" API in host app.
-
-Example:
-    rails generate power_api:public_api_config

--- a/lib/generators/power_api/public_api_config/public_api_config_generator.rb
+++ b/lib/generators/power_api/public_api_config/public_api_config_generator.rb
@@ -1,0 +1,51 @@
+class PowerApi::PublicApiConfigGenerator < Rails::Generators::Base
+  source_root File.expand_path('templates', __dir__)
+
+  class_option(
+    :authenticated_resources,
+    type: 'array',
+    default: [],
+    desc: 'define which model or models will be token authenticatable'
+  )
+
+  def install_rswag
+    generate "rswag:ui:install"
+    generate "rswag:api:install"
+    generate "rswag:specs:install"
+
+    create_file(helper.rswag_ui_initializer_path, helper.rswag_ui_initializer_tpl, force: true)
+    create_file(helper.swagger_helper_path, helper.swagger_helper_tpl, force: true)
+    create_file(helper.spec_swagger_path)
+    create_file(helper.spec_integration_path)
+  end
+
+  def install_first_version
+    generate "power_api:version 1"
+  end
+
+  def install_simple_token_auth
+    create_file(
+      helper.simple_token_auth_initializer_path,
+      helper.simple_token_auth_initializer_tpl,
+      force: true
+    )
+
+    helper.authenticated_resources.each do |resource|
+      generate resource.authenticated_resource_migration
+
+      insert_into_file(
+        resource.path,
+        helper.simple_token_auth_method,
+        after: resource.class_definition_line
+      )
+    end
+  end
+
+  private
+
+  def helper
+    @helper ||= PowerApi::GeneratorHelpers.new(
+      authenticated_resources: options[:authenticated_resources]
+    )
+  end
+end

--- a/lib/generators/power_api/public_api_config/public_api_config_generator.rb
+++ b/lib/generators/power_api/public_api_config/public_api_config_generator.rb
@@ -8,6 +8,13 @@ class PowerApi::PublicApiConfigGenerator < Rails::Generators::Base
     desc: 'define which model or models will be token authenticatable'
   )
 
+  def add_base_controller
+    create_file(
+      helper.exposed_base_controller_path,
+      helper.exposed_base_controller_tpl
+    )
+  end
+
   def install_rswag
     generate "rswag:ui:install"
     generate "rswag:api:install"

--- a/lib/generators/power_api/version/version_generator.rb
+++ b/lib/generators/power_api/version/version_generator.rb
@@ -14,8 +14,8 @@ class PowerApi::VersionGenerator < Rails::Generators::NamedBase
 
   def add_base_controller
     create_file(
-      helper.base_controller_path,
-      helper.base_controller_tpl
+      helper.version_base_controller_path,
+      helper.version_base_controller_tpl
     )
   end
 

--- a/lib/power_api/engine.rb
+++ b/lib/power_api/engine.rb
@@ -13,7 +13,7 @@ module PowerApi
       require_relative "./errors"
       require_relative "./generator_helper/controller_actions_helper"
       require_relative "./generator_helper/active_record_resource"
-      require_relative "./generator_helper/version_helper"
+      require_relative "./generator_helper/api_helper"
       require_relative "./generator_helper/resource_helper"
       require_relative "./generator_helper/swagger_helper"
       require_relative "./generator_helper/ams_helper"

--- a/lib/power_api/engine.rb
+++ b/lib/power_api/engine.rb
@@ -17,6 +17,7 @@ module PowerApi
       require_relative "./generator_helper/resource_helper"
       require_relative "./generator_helper/swagger_helper"
       require_relative "./generator_helper/ams_helper"
+      require_relative "./generator_helper/rspec_controller_helper"
       require_relative "./generator_helper/controller_helper"
       require_relative "./generator_helper/routes_helper"
       require_relative "./generator_helper/pagination_helper"

--- a/lib/power_api/generator_helper/ams_helper.rb
+++ b/lib/power_api/generator_helper/ams_helper.rb
@@ -2,7 +2,7 @@ module PowerApi::GeneratorHelper::AmsHelper
   extend ActiveSupport::Concern
 
   included do
-    include PowerApi::GeneratorHelper::VersionHelper
+    include PowerApi::GeneratorHelper::ApiHelper
     include PowerApi::GeneratorHelper::ResourceHelper
   end
 

--- a/lib/power_api/generator_helper/ams_helper.rb
+++ b/lib/power_api/generator_helper/ams_helper.rb
@@ -11,11 +11,11 @@ module PowerApi::GeneratorHelper::AmsHelper
   end
 
   def ams_serializer_path
-    "app/serializers/api/v#{version_number}/#{resource.snake_case}_serializer.rb"
+    "app/serializers/#{api_file_path_prefix}/#{resource.snake_case}_serializer.rb"
   end
 
   def ams_serializers_path
-    "app/serializers/api/v#{version_number}/.gitkeep"
+    "app/serializers/#{api_file_path_prefix}/.gitkeep"
   end
 
   def ams_initializer_tpl
@@ -32,7 +32,7 @@ module PowerApi::GeneratorHelper::AmsHelper
 
   def ams_serializer_tpl
     <<~SERIALIZER
-      class Api::V#{version_number}::#{resource.camel}Serializer < ActiveModel::Serializer
+      class #{api_class_prefix}::#{resource.camel}Serializer < ActiveModel::Serializer
         type :#{resource.snake_case}
 
         attributes(

--- a/lib/power_api/generator_helper/ams_helper.rb
+++ b/lib/power_api/generator_helper/ams_helper.rb
@@ -11,11 +11,11 @@ module PowerApi::GeneratorHelper::AmsHelper
   end
 
   def ams_serializer_path
-    "app/serializers/#{api_file_path_prefix}/#{resource.snake_case}_serializer.rb"
+    "app/serializers/#{api_file_path}/#{resource.snake_case}_serializer.rb"
   end
 
   def ams_serializers_path
-    "app/serializers/#{api_file_path_prefix}/.gitkeep"
+    "app/serializers/#{api_file_path}/.gitkeep"
   end
 
   def ams_initializer_tpl
@@ -32,7 +32,7 @@ module PowerApi::GeneratorHelper::AmsHelper
 
   def ams_serializer_tpl
     <<~SERIALIZER
-      class #{api_class_prefix}::#{resource.camel}Serializer < ActiveModel::Serializer
+      class #{api_class}::#{resource.camel}Serializer < ActiveModel::Serializer
         type :#{resource.snake_case}
 
         attributes(

--- a/lib/power_api/generator_helper/api_helper.rb
+++ b/lib/power_api/generator_helper/api_helper.rb
@@ -1,4 +1,4 @@
-module PowerApi::GeneratorHelper::VersionHelper
+module PowerApi::GeneratorHelper::ApiHelper
   extend ActiveSupport::Concern
 
   included do

--- a/lib/power_api/generator_helper/api_helper.rb
+++ b/lib/power_api/generator_helper/api_helper.rb
@@ -6,11 +6,32 @@ module PowerApi::GeneratorHelper::ApiHelper
   end
 
   def version_number=(value)
+    if value.blank?
+      @version_number = nil
+      return
+    end
+
     @version_number = value.to_s.to_i
     raise PowerApi::GeneratorError.new("invalid version number") if version_number < 1
   end
 
   def first_version?
     version_number.to_i == 1
+  end
+
+  def versioned_api?
+    !!version_number
+  end
+
+  def api_file_path_prefix
+    return "api/exposed/v#{version_number}" if versioned_api?
+
+    "api/internal"
+  end
+
+  def api_class_prefix
+    return "Api::Exposed::V#{version_number}" if versioned_api?
+
+    "Api::Internal"
   end
 end

--- a/lib/power_api/generator_helper/api_helper.rb
+++ b/lib/power_api/generator_helper/api_helper.rb
@@ -23,15 +23,39 @@ module PowerApi::GeneratorHelper::ApiHelper
     !!version_number
   end
 
-  def api_file_path_prefix
-    return "api/exposed/v#{version_number}" if versioned_api?
+  def api_file_path
+    return version_file_path if versioned_api?
 
+    internal_file_path
+  end
+
+  def version_file_path
+    "#{exposed_file_path}/v#{version_number}"
+  end
+
+  def internal_file_path
     "api/internal"
   end
 
-  def api_class_prefix
-    return "Api::Exposed::V#{version_number}" if versioned_api?
+  def exposed_file_path
+    "api/exposed"
+  end
 
+  def api_class
+    return version_class if versioned_api?
+
+    internal_class
+  end
+
+  def version_class
+    "#{exposed_class}::V#{version_number}"
+  end
+
+  def internal_class
     "Api::Internal"
+  end
+
+  def exposed_class
+    "Api::Exposed"
   end
 end

--- a/lib/power_api/generator_helper/controller_helper.rb
+++ b/lib/power_api/generator_helper/controller_helper.rb
@@ -3,7 +3,7 @@ module PowerApi::GeneratorHelper::ControllerHelper
   extend ActiveSupport::Concern
 
   included do
-    include PowerApi::GeneratorHelper::VersionHelper
+    include PowerApi::GeneratorHelper::ApiHelper
     include PowerApi::GeneratorHelper::ResourceHelper
     include PowerApi::GeneratorHelper::PaginationHelper
     include PowerApi::GeneratorHelper::SimpleTokenAuthHelper

--- a/lib/power_api/generator_helper/controller_helper.rb
+++ b/lib/power_api/generator_helper/controller_helper.rb
@@ -124,7 +124,8 @@ fallback: :exception\n"
 
     concat_tpl_method(
       "update",
-      "respond_with #{resource.snake_case}.update!(#{resource.snake_case}_params)"
+      "#{resource.snake_case}.update!(#{resource.snake_case}_params)",
+      "respond_with #{resource.snake_case}"
     )
   end
 

--- a/lib/power_api/generator_helper/controller_helper.rb
+++ b/lib/power_api/generator_helper/controller_helper.rb
@@ -13,30 +13,55 @@ module PowerApi::GeneratorHelper::ControllerHelper
     attr_accessor :allow_filters
   end
 
-  def api_base_controller_path
+  def api_main_base_controller_path
     "app/controllers/api/base_controller.rb"
   end
 
-  def base_controller_path
-    "app/controllers/api/v#{version_number}/base_controller.rb"
+  def exposed_base_controller_path
+    "app/controllers/#{exposed_file_path}/base_controller.rb"
+  end
+
+  def internal_base_controller_path
+    "app/controllers/#{internal_file_path}/base_controller.rb"
+  end
+
+  def version_base_controller_path
+    "app/controllers/#{version_file_path}/base_controller.rb"
   end
 
   def resource_controller_path
-    "app/controllers/api/v#{version_number}/#{resource.plural}_controller.rb"
+    "app/controllers/#{api_file_path}/#{resource.plural}_controller.rb"
   end
 
-  def api_base_controller_tpl
+  def api_main_base_controller_tpl
     <<~CONTROLLER
       class Api::BaseController < PowerApi::BaseController
       end
     CONTROLLER
   end
 
-  def base_controller_tpl
+  def exposed_base_controller_tpl
     <<~CONTROLLER
-      class Api::V#{version_number}::BaseController < Api::BaseController
+      class #{exposed_class}::BaseController < Api::BaseController
+      end
+    CONTROLLER
+  end
+
+  def internal_base_controller_tpl
+    <<~CONTROLLER
+      class #{internal_class}::BaseController < Api::BaseController
         before_action do
-          self.namespace_for_serializer = ::Api::V#{version_number}
+          self.namespace_for_serializer = ::#{internal_class}
+        end
+      end
+    CONTROLLER
+  end
+
+  def version_base_controller_tpl
+    <<~CONTROLLER
+      class #{version_class}::BaseController < #{exposed_class}::BaseController
+        before_action do
+          self.namespace_for_serializer = ::#{version_class}
         end
       end
     CONTROLLER
@@ -62,8 +87,7 @@ module PowerApi::GeneratorHelper::ControllerHelper
   private
 
   def ctrl_tpl_class_definition_line
-    "Api::V#{version_number}::#{resource.camel_plural}Controller < \
-Api::V#{version_number}::BaseController"
+    "#{api_class}::#{resource.camel_plural}Controller < #{api_class}::BaseController"
   end
 
   def ctrl_tpl_acts_as_token_authentication_handler

--- a/lib/power_api/generator_helper/controller_helper.rb
+++ b/lib/power_api/generator_helper/controller_helper.rb
@@ -70,7 +70,7 @@ module PowerApi::GeneratorHelper::ControllerHelper
   def resource_controller_tpl
     tpl_class(
       ctrl_tpl_class_definition_line,
-      ctrl_tpl_acts_as_token_authentication_handler,
+      ctrl_tpl_authentication_code,
       ctrl_tpl_index,
       ctrl_tpl_show,
       ctrl_tpl_create,
@@ -90,11 +90,15 @@ module PowerApi::GeneratorHelper::ControllerHelper
     "#{api_class}::#{resource.camel_plural}Controller < #{api_class}::BaseController"
   end
 
-  def ctrl_tpl_acts_as_token_authentication_handler
+  def ctrl_tpl_authentication_code
     return unless authenticated_resource?
 
-    "acts_as_token_authentication_handler_for #{authenticated_resource.camel}, \
+    if versioned_api?
+      return "acts_as_token_authentication_handler_for #{authenticated_resource.camel}, \
 fallback: :exception\n"
+    end
+
+    "before_action :authenticate_#{authenticated_resource.snake_case}!\n"
   end
 
   def ctrl_tpl_index

--- a/lib/power_api/generator_helper/routes_helper.rb
+++ b/lib/power_api/generator_helper/routes_helper.rb
@@ -22,8 +22,10 @@ module PowerApi::GeneratorHelper::RoutesHelper
     "routes.draw do\n"
   end
 
-  def api_version_routes_line_regex
-    /#{version_class}[^\n]*/
+  def api_current_route_namespace_line_regex
+    return /#{version_class}[^\n]*/ if versioned_api?
+
+    /namespace :internal[^\n]*/
   end
 
   def parent_resource_routes_line_regex
@@ -38,7 +40,7 @@ module PowerApi::GeneratorHelper::RoutesHelper
 
   def internal_route_tpl
     concat_tpl_statements(
-      "namespace :api do",
+      "namespace :api, defaults: { format: :json } do",
         "namespace :internal do",
         "end",
       "end\n"

--- a/lib/power_api/generator_helper/routes_helper.rb
+++ b/lib/power_api/generator_helper/routes_helper.rb
@@ -19,7 +19,7 @@ module PowerApi::GeneratorHelper::RoutesHelper
   end
 
   def api_version_routes_line_regex
-    /Api::V#{version_number}[^\n]*/
+    /#{version_class}[^\n]*/
   end
 
   def parent_resource_routes_line_regex
@@ -83,7 +83,7 @@ module PowerApi::GeneratorHelper::RoutesHelper
   end
 
   def api_version_params
-    "module: 'Api::V#{version_number}', \
+    "module: '#{version_class}', \
 path: { value: 'v#{version_number}' }, \
 defaults: { format: 'json' }"
   end

--- a/lib/power_api/generator_helper/routes_helper.rb
+++ b/lib/power_api/generator_helper/routes_helper.rb
@@ -1,9 +1,9 @@
-# rubocop:disable Layout/AlignArguments
+# rubocop:disable Layout/AlignParameters
 module PowerApi::GeneratorHelper::RoutesHelper
   extend ActiveSupport::Concern
 
   included do
-    include PowerApi::GeneratorHelper::VersionHelper
+    include PowerApi::GeneratorHelper::ApiHelper
     include PowerApi::GeneratorHelper::ResourceHelper
     include PowerApi::GeneratorHelper::TemplateBuilderHelper
   end
@@ -88,4 +88,4 @@ path: { value: 'v#{version_number}' }, \
 defaults: { format: 'json' }"
   end
 end
-# rubocop:enable Layout/AlignArguments
+# rubocop:enable Layout/AlignParameters

--- a/lib/power_api/generator_helper/routes_helper.rb
+++ b/lib/power_api/generator_helper/routes_helper.rb
@@ -13,9 +13,13 @@ module PowerApi::GeneratorHelper::RoutesHelper
   end
 
   def routes_line_to_inject_new_version
-    return "routes.draw do\n" if first_version?
+    return routes_first_line if first_version?
 
     "'/api' do\n"
+  end
+
+  def routes_first_line
+    "routes.draw do\n"
   end
 
   def api_version_routes_line_regex
@@ -30,6 +34,15 @@ module PowerApi::GeneratorHelper::RoutesHelper
     return first_version_route_tpl if first_version?
 
     new_version_route_tpl
+  end
+
+  def internal_route_tpl
+    concat_tpl_statements(
+      "namespace :api do",
+        "namespace :internal do",
+        "end",
+      "end\n"
+    )
   end
 
   def resource_route_tpl(actions: [], is_parent: false)

--- a/lib/power_api/generator_helper/rspec_controller_helper.rb
+++ b/lib/power_api/generator_helper/rspec_controller_helper.rb
@@ -1,0 +1,294 @@
+# rubocop:disable Metrics/ModuleLength
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Layout/AlignParameters
+module PowerApi::GeneratorHelper::RspecControllerHelper
+  extend ActiveSupport::Concern
+
+  included do
+    include PowerApi::GeneratorHelper::ApiHelper
+    include PowerApi::GeneratorHelper::ResourceHelper
+    include PowerApi::GeneratorHelper::TemplateBuilderHelper
+  end
+
+  def resource_spec_path
+    "spec/requests/#{api_file_path}/#{resource.plural}_spec.rb"
+  end
+
+  def resource_spec_tpl
+    concat_tpl_statements(
+      "require 'rails_helper'\n",
+      concat_tpl_statements(
+        spec_initial_describe_line,
+        spec_authenticated_resource_tpl,
+        spec_let_parent_resource_tpl,
+        spec_index_tpl,
+        spec_create_tpl,
+        spec_show_tpl,
+        spec_update_tpl,
+        spec_destroy_tpl,
+        "end\n"
+      )
+    )
+  end
+
+  private
+
+  def spec_initial_describe_line
+    "RSpec.describe '#{api_class}::#{resource.camel_plural}Controllers', type: :request do"
+  end
+
+  def spec_authenticated_resource_tpl
+    return unless authenticated_resource?
+
+    res_name = authenticated_resource.snake_case
+    "let(:#{res_name}) { create(:#{res_name}) }\n"
+  end
+
+  def spec_let_parent_resource_tpl
+    return unless parent_resource?
+
+    concat_tpl_statements(
+      "let(:#{parent_resource.snake_case}) { create(:#{parent_resource.snake_case}) }",
+      "let(:#{parent_resource.id}) { #{parent_resource.snake_case}.id }\n"
+    )
+  end
+
+  def spec_index_tpl
+    return unless index?
+
+    concat_tpl_statements(
+      "describe 'GET /index' do",
+        "let!(:#{resource.plural}) { #{spec_index_creation_list_tpl} }",
+        "let(:collection) { JSON.parse(response.body)['data'] }",
+        "let(:params) { {} }\n",
+        spec_perform_tpl,
+        with_authorized_resource_context,
+        perform_block_tpl,
+        "it { expect(collection.count).to eq(5) }",
+        "it { expect(response.status).to eq(200) }",
+        conditional_code(authenticated_resource?) { "end\n" },
+        unauthorized_spec_tpl,
+        "end\n"
+    )
+  end
+
+  def spec_create_tpl
+    return unless create?
+
+    concat_tpl_statements(
+      "describe 'POST /create' do",
+      "let(:params) do",
+        "{",
+          "#{resource.snake_case}: {#{resource_parameters}",
+          "}",
+        "}",
+      "end\n",
+      let_resource_attrs,
+      spec_perform_tpl(http_verb: 'post'),
+      with_authorized_resource_context,
+      perform_block_tpl,
+      "it { expect(attributes).to include(params[:#{resource.snake_case}]) }",
+      "it { expect(response.status).to eq(201) }",
+      spec_invalid_attrs_test_tpl,
+      conditional_code(authenticated_resource?) { "end\n" },
+      unauthorized_spec_tpl,
+      "end\n"
+    )
+  end
+
+  def spec_show_tpl
+    return unless show?
+
+    concat_tpl_statements(
+      "describe 'GET /show' do",
+      spec_let_existent_resource_tpl,
+      "let(:#{resource.snake_case}_id) { #{resource.snake_case}.id.to_s }\n",
+      let_resource_attrs,
+      spec_perform_tpl(http_verb: 'get', params: false, single_resource: true),
+      with_authorized_resource_context,
+      perform_block_tpl,
+      "it { expect(response.status).to eq(200) }",
+      "context 'with resource not found' do",
+      "let(:#{resource.snake_case}_id) { '666' }",
+      "it { expect(response.status).to eq(404) }",
+      "end",
+      conditional_code(authenticated_resource?) { "end\n" },
+      unauthorized_spec_tpl,
+      "end\n"
+    )
+  end
+
+  def spec_update_tpl
+    return unless update?
+
+    concat_tpl_statements(
+      "describe 'PUT /update' do",
+      spec_let_existent_resource_tpl,
+      "let(:#{resource.snake_case}_id) { #{resource.snake_case}.id.to_s }\n",
+      "let(:params) do",
+        "{",
+          "#{resource.snake_case}: {#{resource_parameters}",
+          "}",
+        "}",
+      "end\n",
+      let_resource_attrs,
+      spec_perform_tpl(http_verb: 'put', params: true, single_resource: true),
+      with_authorized_resource_context,
+      perform_block_tpl,
+      "it { expect(attributes).to include(params[:#{resource.snake_case}]) }",
+      "it { expect(response.status).to eq(200) }",
+      spec_invalid_attrs_test_tpl,
+      "context 'with resource not found' do",
+      "let(:#{resource.snake_case}_id) { '666' }",
+      "it { expect(response.status).to eq(404) }",
+      "end",
+      conditional_code(authenticated_resource?) { "end\n" },
+      unauthorized_spec_tpl,
+      "end\n"
+    )
+  end
+
+  def spec_destroy_tpl
+    return unless destroy?
+
+    concat_tpl_statements(
+      "describe 'DELETE /destroy' do",
+      spec_let_existent_resource_tpl,
+      "let(:#{resource.snake_case}_id) { #{resource.snake_case}.id.to_s }\n",
+      spec_perform_tpl(http_verb: 'get', params: false, single_resource: true),
+      with_authorized_resource_context,
+      perform_block_tpl,
+      "it { expect(response.status).to eq(200) }",
+      "context 'with resource not found' do",
+      "let(:#{resource.snake_case}_id) { '666' }",
+      "it { expect(response.status).to eq(404) }",
+      "end",
+      conditional_code(authenticated_resource?) { "end\n" },
+      unauthorized_spec_tpl,
+      "end\n"
+    )
+  end
+
+  def spec_let_existent_resource_tpl
+    statement = ["let(:#{resource.snake_case}) { create(:#{resource.snake_case}"]
+    load_owner_resource_factory_option(statement)
+    statement.join(', ') + ') }'
+  end
+
+  def spec_invalid_attrs_test_tpl
+    return if resource.required_resource_attributes.blank?
+
+    concat_tpl_statements(
+      "context 'with invalid attributes' do",
+        "let(:params) do",
+          "{",
+            "#{resource.snake_case}: {#{invalid_resource_params}}",
+          "}",
+        "end\n",
+        "it { expect(response.status).to eq(400) }",
+      "end\n"
+    )
+  end
+
+  def with_authorized_resource_context
+    conditional_code(authenticated_resource?) do
+      "context 'with authorized #{authenticated_resource.snake_case}' do"
+    end
+  end
+
+  def let_resource_attrs
+    concat_tpl_statements(
+      "let(:attributes) do",
+        "JSON.parse(response.body)['data']['attributes'].symbolize_keys",
+      "end"
+    )
+  end
+
+  def perform_block_tpl(auth: true)
+    concat_tpl_statements(
+      "before do",
+        conditional_code(auth && authenticated_resource?) do
+          "sign_in(#{authenticated_resource.snake_case})"
+        end,
+        "perform",
+      "end\n"
+    )
+  end
+
+  def spec_perform_tpl(http_verb: 'get', params: true, single_resource: false)
+    body = "#{http_verb} '/#{spec_collection_path}"
+    body += "/' + #{resource.snake_case}_id" if single_resource
+    body += "'" unless single_resource
+    body += ", params: params" if params
+
+    concat_tpl_statements(
+      "def perform",
+      body,
+      "end\n"
+    )
+  end
+
+  def spec_collection_path
+    path = ["api"]
+    path << (versioned_api? ? "v#{version_number}" : "internal")
+
+    if parent_resource?
+      path << parent_resource.plural
+      path << "' + #{parent_resource.snake_case}.id.to_s + '"
+    end
+
+    path << resource.plural
+    path.join("/")
+  end
+
+  def spec_index_creation_list_tpl
+    statement = ["create_list(:#{resource.snake_case}, 5"]
+    load_owner_resource_factory_option(statement)
+    statement.join(', ') + ')'
+  end
+
+  def load_owner_resource_factory_option(statement)
+    if parent_resource?
+      statement << "#{parent_resource.snake_case}: #{parent_resource.snake_case}"
+    end
+
+    if owned_by_authenticated_resource?
+      statement << "#{authenticated_resource.snake_case}: #{authenticated_resource.snake_case}"
+    end
+  end
+
+  def unauthorized_spec_tpl
+    return unless authenticated_resource?
+
+    authenticated_resource_name = authenticated_resource.snake_case
+    concat_tpl_statements(
+      "context 'with unauthorized #{authenticated_resource_name}' do",
+        "before { perform }\n",
+        "it { expect(response.status).to eq(401) }",
+      "end\n"
+    )
+  end
+
+  def resource_parameters
+    attrs = if resource.required_resource_attributes.any?
+              resource.required_resource_attributes
+            else
+              resource.optional_resource_attributes
+            end
+
+    for_each_attribute(attrs) do |attr|
+      "#{attr[:name]}: #{attr[:example]},"
+    end
+  end
+
+  def for_each_attribute(attributes)
+    attributes.inject("") do |memo, attr|
+      memo += "\n"
+      memo += yield(attr)
+      memo
+    end.delete_suffix(",")
+  end
+end
+# rubocop:enable Metrics/ModuleLength
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Layout/AlignParameters

--- a/lib/power_api/generator_helper/rspec_controller_helper.rb
+++ b/lib/power_api/generator_helper/rspec_controller_helper.rb
@@ -262,7 +262,7 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
 
     authenticated_resource_name = authenticated_resource.snake_case
     concat_tpl_statements(
-      "context 'with unauthorized #{authenticated_resource_name}' do",
+      "context 'with unauthenticated #{authenticated_resource_name}' do",
         "before { perform }\n",
         "it { expect(response.status).to eq(401) }",
       "end\n"

--- a/lib/power_api/generator_helper/rspec_controller_helper.rb
+++ b/lib/power_api/generator_helper/rspec_controller_helper.rb
@@ -66,7 +66,9 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
         perform_block_tpl,
         "it { expect(collection.count).to eq(5) }",
         "it { expect(response.status).to eq(200) }",
-        conditional_code(authenticated_resource?) { "end\n" },
+        if authenticated_resource?
+          "end\n"
+        end,
         unauthorized_spec_tpl,
         "end\n"
     )
@@ -90,7 +92,9 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
       "it { expect(attributes).to include(params[:#{resource.snake_case}]) }",
       "it { expect(response.status).to eq(201) }",
       spec_invalid_attrs_test_tpl,
-      conditional_code(authenticated_resource?) { "end\n" },
+      if authenticated_resource?
+        "end\n"
+      end,
       unauthorized_spec_tpl,
       "end\n"
     )
@@ -112,7 +116,9 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
       "let(:#{resource.snake_case}_id) { '666' }",
       "it { expect(response.status).to eq(404) }",
       "end",
-      conditional_code(authenticated_resource?) { "end\n" },
+      if authenticated_resource?
+        "end\n"
+      end,
       unauthorized_spec_tpl,
       "end\n"
     )
@@ -142,7 +148,9 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
       "let(:#{resource.snake_case}_id) { '666' }",
       "it { expect(response.status).to eq(404) }",
       "end",
-      conditional_code(authenticated_resource?) { "end\n" },
+      if authenticated_resource?
+        "end\n"
+      end,
       unauthorized_spec_tpl,
       "end\n"
     )
@@ -163,7 +171,9 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
       "let(:#{resource.snake_case}_id) { '666' }",
       "it { expect(response.status).to eq(404) }",
       "end",
-      conditional_code(authenticated_resource?) { "end\n" },
+      if authenticated_resource?
+        "end\n"
+      end,
       unauthorized_spec_tpl,
       "end\n"
     )
@@ -191,7 +201,7 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
   end
 
   def with_authorized_resource_context
-    conditional_code(authenticated_resource?) do
+    if authenticated_resource?
       "context 'with authorized #{authenticated_resource.snake_case}' do"
     end
   end
@@ -207,7 +217,7 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
   def perform_block_tpl(auth: true)
     concat_tpl_statements(
       "before do",
-        conditional_code(auth && authenticated_resource?) do
+        if auth && authenticated_resource?
           "sign_in(#{authenticated_resource.snake_case})"
         end,
         "perform",

--- a/lib/power_api/generator_helper/rspec_controller_helper.rb
+++ b/lib/power_api/generator_helper/rspec_controller_helper.rb
@@ -41,7 +41,7 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
     return unless authenticated_resource?
 
     res_name = authenticated_resource.snake_case
-    "let(:#{res_name}) { create(:#{res_name}) }\n"
+    "let(:#{res_name}) { create(:#{res_name}) }"
   end
 
   def spec_let_parent_resource_tpl
@@ -216,7 +216,7 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
   end
 
   def spec_perform_tpl(http_verb: 'get', params: true, single_resource: false)
-    body = "#{http_verb} '/#{spec_collection_path}"
+    body = "#{http_verb} '/#{spec_collection_path(single_resource)}"
     body += "/' + #{resource.snake_case}_id" if single_resource
     body += "'" unless single_resource
     body += ", params: params" if params
@@ -228,11 +228,11 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
     )
   end
 
-  def spec_collection_path
+  def spec_collection_path(single_resource)
     path = ["api"]
     path << (versioned_api? ? "v#{version_number}" : "internal")
 
-    if parent_resource?
+    if parent_resource? && !single_resource
       path << parent_resource.plural
       path << "' + #{parent_resource.snake_case}.id.to_s + '"
     end
@@ -283,6 +283,8 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
 
   def for_each_attribute(attributes)
     attributes.inject("") do |memo, attr|
+      next memo if parent_resource && attr[:name] == parent_resource.id.to_sym
+
       memo += "\n"
       memo += yield(attr)
       memo

--- a/lib/power_api/generator_helper/swagger_helper.rb
+++ b/lib/power_api/generator_helper/swagger_helper.rb
@@ -1,11 +1,11 @@
 # rubocop:disable Metrics/ModuleLength
 # rubocop:disable Metrics/MethodLength
-# rubocop:disable Layout/AlignArguments
+# rubocop:disable Layout/AlignParameters
 module PowerApi::GeneratorHelper::SwaggerHelper
   extend ActiveSupport::Concern
 
   included do
-    include PowerApi::GeneratorHelper::VersionHelper
+    include PowerApi::GeneratorHelper::ApiHelper
     include PowerApi::GeneratorHelper::ResourceHelper
     include PowerApi::GeneratorHelper::SimpleTokenAuthHelper
     include PowerApi::GeneratorHelper::TemplateBuilderHelper
@@ -475,4 +475,4 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
 end
 # rubocop:enable Metrics/ModuleLength
 # rubocop:enable Metrics/MethodLength
-# rubocop:enable Layout/AlignArguments
+# rubocop:enable Layout/AlignParameters

--- a/lib/power_api/generator_helper/template_builder_helper.rb
+++ b/lib/power_api/generator_helper/template_builder_helper.rb
@@ -5,6 +5,12 @@ module PowerApi::GeneratorHelper::TemplateBuilderHelper
     methods.reject(&:blank?).join("\n")
   end
 
+  def conditional_code(condition)
+    return unless condition
+
+    yield
+  end
+
   def concat_tpl_method(method_name, *method_lines)
     concat_tpl_statements(
       "def #{method_name}",

--- a/lib/power_api/generator_helper/template_builder_helper.rb
+++ b/lib/power_api/generator_helper/template_builder_helper.rb
@@ -5,12 +5,6 @@ module PowerApi::GeneratorHelper::TemplateBuilderHelper
     methods.reject(&:blank?).join("\n")
   end
 
-  def conditional_code(condition)
-    return unless condition
-
-    yield
-  end
-
   def concat_tpl_method(method_name, *method_lines)
     concat_tpl_statements(
       "def #{method_name}",

--- a/lib/power_api/generator_helpers.rb
+++ b/lib/power_api/generator_helpers.rb
@@ -4,6 +4,7 @@ module PowerApi
     include GeneratorHelper::ResourceHelper
     include GeneratorHelper::ApiHelper
     include GeneratorHelper::SwaggerHelper
+    include GeneratorHelper::RspecControllerHelper
     include GeneratorHelper::AmsHelper
     include GeneratorHelper::ControllerHelper
     include GeneratorHelper::RoutesHelper

--- a/lib/power_api/generator_helpers.rb
+++ b/lib/power_api/generator_helpers.rb
@@ -2,7 +2,7 @@ module PowerApi
   class GeneratorHelpers
     include GeneratorHelper::ControllerActionsHelper
     include GeneratorHelper::ResourceHelper
-    include GeneratorHelper::VersionHelper
+    include GeneratorHelper::ApiHelper
     include GeneratorHelper::SwaggerHelper
     include GeneratorHelper::AmsHelper
     include GeneratorHelper::ControllerHelper

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,12 +1,2 @@
 Rails.application.routes.draw do
-  mount Rswag::Api::Engine => '/api-docs'
-  mount Rswag::Ui::Engine => '/api-docs'
-  scope path: '/api' do
-    api_version(module: 'Api::V2', path: { value: 'v2' }, defaults: { format: 'json' }) do
-    end
-
-    api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
-      resources :blogs
-    end
-  end
 end

--- a/spec/dummy/spec/lib/power_api/generator_helper/ams_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/ams_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
 
   describe "#ams_serializers_path" do
     let(:expected_path) do
-      "app/serializers/api/v1/.gitkeep"
+      "app/serializers/api/exposed/v1/.gitkeep"
     end
 
     def perform
@@ -24,7 +24,17 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
       let(:version_number) { "2" }
 
       let(:expected_path) do
-        "app/serializers/api/v2/.gitkeep"
+        "app/serializers/api/exposed/v2/.gitkeep"
+      end
+
+      it { expect(perform).to eq(expected_path) }
+    end
+
+    context "with no version" do
+      let(:version_number) { "" }
+
+      let(:expected_path) do
+        "app/serializers/api/internal/.gitkeep"
       end
 
       it { expect(perform).to eq(expected_path) }
@@ -32,13 +42,23 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
   end
 
   describe "#ams_serializer_path" do
-    let(:expected_path) { "app/serializers/api/v1/blog_serializer.rb" }
+    let(:expected_path) { "app/serializers/api/exposed/v1/blog_serializer.rb" }
 
     def perform
       generators_helper.ams_serializer_path
     end
 
     it { expect(perform).to eq(expected_path) }
+
+    context "with no version" do
+      let(:version_number) { nil }
+
+      let(:expected_path) do
+        "app/serializers/api/internal/blog_serializer.rb"
+      end
+
+      it { expect(perform).to eq(expected_path) }
+    end
   end
 
   describe "ams_initializer_tpl" do
@@ -64,7 +84,7 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
   describe "ams_serializer_tpl" do
     let(:template) do
       <<~SERIALIZER
-        class Api::V1::BlogSerializer < ActiveModel::Serializer
+        class Api::Exposed::V1::BlogSerializer < ActiveModel::Serializer
           type :blog
 
           attributes(
@@ -83,5 +103,27 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
     end
 
     it { expect(perform).to eq(template) }
+
+    context "with no version" do
+      let(:version_number) { nil }
+
+      let(:template) do
+        <<~SERIALIZER
+          class Api::Internal::BlogSerializer < ActiveModel::Serializer
+            type :blog
+
+            attributes(
+              :title,
+          :body,
+          :created_at,
+          :updated_at,
+          :portfolio_id
+          )
+          end
+        SERIALIZER
+      end
+
+      it { expect(perform).to eq(template) }
+    end
   end
 end

--- a/spec/dummy/spec/lib/power_api/generator_helper/api_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/api_helper_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe PowerApi::GeneratorHelper::ApiHelper, type: :generator do
     context "with nil version number" do
       let(:version_number) { nil }
 
-      it { expect { generators_helper }.to raise_error("invalid version number") }
+      it { expect { generators_helper }.not_to raise_error }
     end
 
     context "with nil blank number" do
       let(:version_number) { "" }
 
-      it { expect { generators_helper }.to raise_error("invalid version number") }
+      it { expect { generators_helper }.not_to raise_error }
     end
 
     context "with negative version number" do
@@ -50,6 +50,66 @@ RSpec.describe PowerApi::GeneratorHelper::ApiHelper, type: :generator do
       let(:version_number) { "2" }
 
       it { expect(perform).to eq(false) }
+    end
+  end
+
+  describe "#versioned_api?" do
+    def perform
+      generators_helper.versioned_api?
+    end
+
+    it { expect(perform).to eq(true) }
+
+    context "when version in not first version" do
+      let(:version_number) { "2" }
+
+      it { expect(perform).to eq(true) }
+    end
+
+    context "when nil version" do
+      let(:version_number) { nil }
+
+      it { expect(perform).to eq(false) }
+    end
+  end
+
+  describe "#api_file_path_prefix" do
+    def perform
+      generators_helper.api_file_path_prefix
+    end
+
+    it { expect(perform).to eq("api/exposed/v1") }
+
+    context "when version in not first version" do
+      let(:version_number) { "2" }
+
+      it { expect(perform).to eq("api/exposed/v2") }
+    end
+
+    context "when nil version" do
+      let(:version_number) { nil }
+
+      it { expect(perform).to eq("api/internal") }
+    end
+  end
+
+  describe "#api_class_prefix" do
+    def perform
+      generators_helper.api_class_prefix
+    end
+
+    it { expect(perform).to eq("Api::Exposed::V1") }
+
+    context "when version in not first version" do
+      let(:version_number) { "2" }
+
+      it { expect(perform).to eq("Api::Exposed::V2") }
+    end
+
+    context "when nil version" do
+      let(:version_number) { nil }
+
+      it { expect(perform).to eq("Api::Internal") }
     end
   end
 end

--- a/spec/dummy/spec/lib/power_api/generator_helper/api_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/api_helper_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe PowerApi::GeneratorHelper::ApiHelper, type: :generator do
     end
   end
 
-  describe "#api_file_path_prefix" do
+  describe "#api_file_path" do
     def perform
-      generators_helper.api_file_path_prefix
+      generators_helper.api_file_path
     end
 
     it { expect(perform).to eq("api/exposed/v1") }
@@ -93,9 +93,9 @@ RSpec.describe PowerApi::GeneratorHelper::ApiHelper, type: :generator do
     end
   end
 
-  describe "#api_class_prefix" do
+  describe "#api_class" do
     def perform
-      generators_helper.api_class_prefix
+      generators_helper.api_class
     end
 
     it { expect(perform).to eq("Api::Exposed::V1") }

--- a/spec/dummy/spec/lib/power_api/generator_helper/api_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/api_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PowerApi::GeneratorHelper::VersionHelper, type: :generator do
+RSpec.describe PowerApi::GeneratorHelper::ApiHelper, type: :generator do
   describe "#version_number" do
     def perform
       generators_helper.version_number

--- a/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
@@ -140,7 +140,8 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
         respond_with Blog.create!(blog_params)
         end
         def update
-        respond_with blog.update!(blog_params)
+        blog.update!(blog_params)
+        respond_with blog
         end
         def destroy
         respond_with blog.destroy!
@@ -297,7 +298,8 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
           respond_with Blog.create!(blog_params)
           end
           def update
-          respond_with blog.update!(blog_params)
+          blog.update!(blog_params)
+          respond_with blog
           end
           def destroy
           respond_with blog.destroy!
@@ -348,7 +350,8 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
           respond_with blogs.create!(blog_params)
           end
           def update
-          respond_with blog.update!(blog_params)
+          blog.update!(blog_params)
+          respond_with blog
           end
           def destroy
           respond_with blog.destroy!
@@ -396,7 +399,8 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
           respond_with blogs.create!(blog_params)
           end
           def update
-          respond_with blog.update!(blog_params)
+          blog.update!(blog_params)
+          respond_with blog
           end
           def destroy
           respond_with blog.destroy!
@@ -444,7 +448,8 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
           respond_with blogs.create!(blog_params)
           end
           def update
-          respond_with blog.update!(blog_params)
+          blog.update!(blog_params)
+          respond_with blog
           end
           def destroy
           respond_with blog.destroy!

--- a/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
@@ -1,46 +1,68 @@
 RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
-  describe "#api_base_controller_path" do
+  describe "#api_main_base_controller_path" do
     let(:expected_path) { "app/controllers/api/base_controller.rb" }
 
     def perform
-      generators_helper.api_base_controller_path
+      generators_helper.api_main_base_controller_path
+    end
+
+    it { expect(perform).to eq(expected_path) }
+  end
+
+  describe "#exposed_base_controller_path" do
+    let(:expected_path) { "app/controllers/api/exposed/base_controller.rb" }
+
+    def perform
+      generators_helper.exposed_base_controller_path
+    end
+
+    it { expect(perform).to eq(expected_path) }
+  end
+
+  describe "#internal_base_controller_path" do
+    let(:expected_path) { "app/controllers/api/internal/base_controller.rb" }
+
+    def perform
+      generators_helper.internal_base_controller_path
+    end
+
+    it { expect(perform).to eq(expected_path) }
+  end
+
+  describe "#version_base_controller_path" do
+    let(:expected_path) { "app/controllers/api/exposed/v1/base_controller.rb" }
+
+    def perform
+      generators_helper.version_base_controller_path
     end
 
     it { expect(perform).to eq(expected_path) }
   end
 
   describe "#resource_controller_path" do
-    let(:expected_path) { "app/controllers/api/v1/blogs_controller.rb" }
+    let(:expected_path) { "app/controllers/api/exposed/v1/blogs_controller.rb" }
 
     def perform
       generators_helper.resource_controller_path
     end
 
     it { expect(perform).to eq(expected_path) }
+
+    context "without version" do
+      let(:version_number) { "" }
+      let(:expected_path) { "app/controllers/api/internal/blogs_controller.rb" }
+
+      it { expect(perform).to eq(expected_path) }
+    end
   end
 
-  describe "api_base_controller_tpl" do
-    let(:template) do
-      <<~CONTROLLER
-        class Api::BaseController < PowerApi::BaseController
-        end
-      CONTROLLER
-    end
-
-    def perform
-      generators_helper.api_base_controller_tpl
-    end
-
-    it { expect(perform).to eq(template) }
-  end
-
-  describe "#base_controller_path" do
+  describe "#version_base_controller_path" do
     let(:expected_path) do
-      "app/controllers/api/v1/base_controller.rb"
+      "app/controllers/api/exposed/v1/base_controller.rb"
     end
 
     def perform
-      generators_helper.base_controller_path
+      generators_helper.version_base_controller_path
     end
 
     it { expect(perform).to eq(expected_path) }
@@ -49,17 +71,65 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
       let(:version_number) { "2" }
 
       let(:expected_path) do
-        "app/controllers/api/v2/base_controller.rb"
+        "app/controllers/api/exposed/v2/base_controller.rb"
       end
 
       it { expect(perform).to eq(expected_path) }
     end
   end
 
+  describe "api_main_base_controller_tpl" do
+    let(:template) do
+      <<~CONTROLLER
+        class Api::BaseController < PowerApi::BaseController
+        end
+      CONTROLLER
+    end
+
+    def perform
+      generators_helper.api_main_base_controller_tpl
+    end
+
+    it { expect(perform).to eq(template) }
+  end
+
+  describe "exposed_base_controller_tpl" do
+    let(:template) do
+      <<~CONTROLLER
+        class Api::Exposed::BaseController < Api::BaseController
+        end
+      CONTROLLER
+    end
+
+    def perform
+      generators_helper.exposed_base_controller_tpl
+    end
+
+    it { expect(perform).to eq(template) }
+  end
+
+  describe "internal_base_controller_tpl" do
+    let(:template) do
+      <<~CONTROLLER
+        class Api::Internal::BaseController < Api::BaseController
+          before_action do
+            self.namespace_for_serializer = ::Api::Internal
+          end
+        end
+      CONTROLLER
+    end
+
+    def perform
+      generators_helper.internal_base_controller_tpl
+    end
+
+    it { expect(perform).to eq(template) }
+  end
+
   describe "resource_controller_tpl" do
     let(:template) do
       <<~CONTROLLER
-        class Api::V1::BlogsController < Api::V1::BaseController
+        class Api::Exposed::V1::BlogsController < Api::Exposed::V1::BaseController
         def index
         respond_with Blog.all
         end
@@ -95,6 +165,13 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
     end
 
     it { expect(perform).to eq(template) }
+
+    context "without version" do
+      let(:version_number) { nil }
+      let(:expected) { "class Api::Internal::BlogsController < Api::Internal::BaseController" }
+
+      it { expect(perform).to include(expected) }
+    end
 
     context "with specific attributes" do
       let(:resource_attributes) do
@@ -207,7 +284,7 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
       let(:authenticated_resource) { "user" }
       let(:template) do
         <<~CONTROLLER
-          class Api::V1::BlogsController < Api::V1::BaseController
+          class Api::Exposed::V1::BlogsController < Api::Exposed::V1::BaseController
           acts_as_token_authentication_handler_for User, fallback: :exception
 
           def index
@@ -249,7 +326,7 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
 
       let(:template) do
         <<~CONTROLLER
-          class Api::V1::BlogsController < Api::V1::BaseController
+          class Api::Exposed::V1::BlogsController < Api::Exposed::V1::BaseController
           acts_as_token_authentication_handler_for User, fallback: :exception
 
           def index
@@ -299,7 +376,7 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
       let(:parent_resource_name) { "portfolio" }
       let(:template) do
         <<~CONTROLLER
-          class Api::V1::BlogsController < Api::V1::BaseController
+          class Api::Exposed::V1::BlogsController < Api::Exposed::V1::BaseController
           def index
           respond_with blogs
           end
@@ -345,7 +422,7 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
       let(:owned_by_authenticated_resource) { true }
       let(:template) do
         <<~CONTROLLER
-          class Api::V1::BlogsController < Api::V1::BaseController
+          class Api::Exposed::V1::BlogsController < Api::Exposed::V1::BaseController
           acts_as_token_authentication_handler_for User, fallback: :exception
 
           def index
@@ -388,19 +465,19 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
     end
   end
 
-  describe "#base_controller_tpl" do
+  describe "#version_base_controller_tpl" do
     let(:expected_tpl) do
       <<~CONTROLLER
-        class Api::V1::BaseController < Api::BaseController
+        class Api::Exposed::V1::BaseController < Api::Exposed::BaseController
           before_action do
-            self.namespace_for_serializer = ::Api::V1
+            self.namespace_for_serializer = ::Api::Exposed::V1
           end
         end
       CONTROLLER
     end
 
     def perform
-      generators_helper.base_controller_tpl
+      generators_helper.version_base_controller_tpl
     end
 
     it { expect(perform).to eq(expected_tpl) }
@@ -410,9 +487,9 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
 
       let(:expected_tpl) do
         <<~CONTROLLER
-          class Api::V2::BaseController < Api::BaseController
+          class Api::Exposed::V2::BaseController < Api::Exposed::BaseController
             before_action do
-              self.namespace_for_serializer = ::Api::V2
+              self.namespace_for_serializer = ::Api::Exposed::V2
             end
           end
         CONTROLLER

--- a/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
@@ -318,6 +318,15 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
       end
 
       it { expect(perform).to eq(template) }
+
+      context "without version" do
+        let(:version_number) { nil }
+        let(:expected) do
+          "before_action :authenticate_user!"
+        end
+
+        it { expect(perform).to include(expected) }
+      end
     end
 
     context "with owned_by_authenticated_resource and authenticated_resource" do

--- a/spec/dummy/spec/lib/power_api/generator_helper/routes_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/routes_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PowerApi::GeneratorHelper::RoutesHelper, type: :generator do
   end
 
   describe "#api_version_routes_line_regex" do
-    let(:expected_regex) { /Api::V1[^\n]*/ }
+    let(:expected_regex) { /Api::Exposed::V1[^\n]*/ }
 
     def perform
       generators_helper.api_version_routes_line_regex
@@ -87,7 +87,7 @@ RSpec.describe PowerApi::GeneratorHelper::RoutesHelper, type: :generator do
     let(:expected_tpl) do
       <<~ROUTE
         scope path: '/api' do
-        api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
+        api_version(module: 'Api::Exposed::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
         end
         end
       ROUTE
@@ -104,13 +104,30 @@ RSpec.describe PowerApi::GeneratorHelper::RoutesHelper, type: :generator do
 
       let(:expected_tpl) do
         <<~ROUTE
-          api_version(module: 'Api::V2', path: { value: 'v2' }, defaults: { format: 'json' }) do
+          api_version(module: 'Api::Exposed::V2', path: { value: 'v2' }, defaults: { format: 'json' }) do
           end
         ROUTE
       end
 
       it { expect(perform).to eq(expected_tpl.delete_suffix("\n")) }
     end
+  end
+
+  describe "#internal_route_tpl" do
+    let(:expected_tpl) do
+      <<~ROUTE
+        namespace :api do
+        namespace :internal do
+        end
+        end
+      ROUTE
+    end
+
+    def perform
+      generators_helper.internal_route_tpl
+    end
+
+    it { expect(perform).to eq(expected_tpl) }
   end
 
   describe "#parent_route_exist?" do

--- a/spec/dummy/spec/lib/power_api/generator_helper/routes_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/routes_helper_spec.rb
@@ -9,14 +9,21 @@ RSpec.describe PowerApi::GeneratorHelper::RoutesHelper, type: :generator do
     it { expect(perform).to eq(expected_path) }
   end
 
-  describe "#api_version_routes_line_regex" do
+  describe "#api_current_route_namespace_line_regex" do
     let(:expected_regex) { /Api::Exposed::V1[^\n]*/ }
 
     def perform
-      generators_helper.api_version_routes_line_regex
+      generators_helper.api_current_route_namespace_line_regex
     end
 
     it { expect(perform).to eq(expected_regex) }
+
+    context "without version" do
+      let(:version_number) { "" }
+      let(:expected_regex) { /namespace :internal[^\n]*/ }
+
+      it { expect(perform).to eq(expected_regex) }
+    end
   end
 
   describe "#parent_resource_routes_line_regex" do
@@ -116,7 +123,7 @@ RSpec.describe PowerApi::GeneratorHelper::RoutesHelper, type: :generator do
   describe "#internal_route_tpl" do
     let(:expected_tpl) do
       <<~ROUTE
-        namespace :api do
+        namespace :api, defaults: { format: :json } do
         namespace :internal do
         end
         end

--- a/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
@@ -204,7 +204,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           it { expect(response.status).to eq(200) }
           end
 
-          context 'with unauthorized user' do
+          context 'with unauthenticated user' do
           before { perform }
 
           it { expect(response.status).to eq(401) }
@@ -250,7 +250,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
 
           end
 
-          context 'with unauthorized user' do
+          context 'with unauthenticated user' do
           before { perform }
 
           it { expect(response.status).to eq(401) }
@@ -282,7 +282,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           end
           end
 
-          context 'with unauthorized user' do
+          context 'with unauthenticated user' do
           before { perform }
 
           it { expect(response.status).to eq(401) }
@@ -335,7 +335,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           end
           end
 
-          context 'with unauthorized user' do
+          context 'with unauthenticated user' do
           before { perform }
 
           it { expect(response.status).to eq(401) }
@@ -364,7 +364,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           end
           end
 
-          context 'with unauthorized user' do
+          context 'with unauthenticated user' do
           before { perform }
 
           it { expect(response.status).to eq(401) }

--- a/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
@@ -1,0 +1,414 @@
+describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
+  describe "#resource_spec_path" do
+    let(:expected_path) { "spec/requests/api/exposed/v1/blogs_spec.rb" }
+
+    def perform
+      generators_helper.resource_spec_path
+    end
+
+    it { expect(perform).to eq(expected_path) }
+
+    context "when nil version" do
+      let(:version_number) { nil }
+      let(:expected_path) { "spec/requests/api/internal/blogs_spec.rb" }
+
+      it { expect(perform).to eq(expected_path) }
+    end
+  end
+
+  describe "#resource_spec_tpl" do
+    let(:template) do
+      <<~SPEC
+        require 'rails_helper'
+
+        RSpec.describe 'Api::Exposed::V1::BlogsControllers', type: :request do
+        describe 'GET /index' do
+        let!(:blogs) { create_list(:blog, 5) }
+        let(:collection) { JSON.parse(response.body)['data'] }
+        let(:params) { {} }
+
+        def perform
+        get '/api/v1/blogs', params: params
+        end
+
+        before do
+        perform
+        end
+
+        it { expect(collection.count).to eq(5) }
+        it { expect(response.status).to eq(200) }
+        end
+
+        describe 'POST /create' do
+        let(:params) do
+        {
+        blog: {
+        title: 'Some title',
+        body: 'Some body'
+        }
+        }
+        end
+
+        let(:attributes) do
+        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        end
+        def perform
+        post '/api/v1/blogs', params: params
+        end
+
+        before do
+        perform
+        end
+
+        it { expect(attributes).to include(params[:blog]) }
+        it { expect(response.status).to eq(201) }
+        context 'with invalid attributes' do
+        let(:params) do
+        {
+        blog: {
+        title: nil}
+        }
+        end
+
+        it { expect(response.status).to eq(400) }
+        end
+
+        end
+
+        describe 'GET /show' do
+        let(:blog) { create(:blog) }
+        let(:blog_id) { blog.id.to_s }
+
+        let(:attributes) do
+        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        end
+        def perform
+        get '/api/v1/blogs/' + blog_id
+        end
+
+        before do
+        perform
+        end
+
+        it { expect(response.status).to eq(200) }
+        context 'with resource not found' do
+        let(:blog_id) { '666' }
+        it { expect(response.status).to eq(404) }
+        end
+        end
+
+        describe 'PUT /update' do
+        let(:blog) { create(:blog) }
+        let(:blog_id) { blog.id.to_s }
+
+        let(:params) do
+        {
+        blog: {
+        title: 'Some title',
+        body: 'Some body'
+        }
+        }
+        end
+
+        let(:attributes) do
+        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        end
+        def perform
+        put '/api/v1/blogs/' + blog_id, params: params
+        end
+
+        before do
+        perform
+        end
+
+        it { expect(attributes).to include(params[:blog]) }
+        it { expect(response.status).to eq(200) }
+        context 'with invalid attributes' do
+        let(:params) do
+        {
+        blog: {
+        title: nil}
+        }
+        end
+
+        it { expect(response.status).to eq(400) }
+        end
+
+        context 'with resource not found' do
+        let(:blog_id) { '666' }
+        it { expect(response.status).to eq(404) }
+        end
+        end
+
+        describe 'DELETE /destroy' do
+        let(:blog) { create(:blog) }
+        let(:blog_id) { blog.id.to_s }
+
+        def perform
+        get '/api/v1/blogs/' + blog_id
+        end
+
+        before do
+        perform
+        end
+
+        it { expect(response.status).to eq(200) }
+        context 'with resource not found' do
+        let(:blog_id) { '666' }
+        it { expect(response.status).to eq(404) }
+        end
+        end
+
+        end
+      SPEC
+    end
+
+    def perform
+      generators_helper.resource_spec_tpl
+    end
+
+    it { expect(perform).to eq(template) }
+
+    context "when nil version" do
+      let(:version_number) { nil }
+
+      it { expect(perform).to include("RSpec.describe 'Api::Internal::BlogsControllers'") }
+      it { expect(perform).to include("get '/api/internal/blogs', params: params") }
+    end
+
+    context "with authenticated_resource option" do
+      let(:authenticated_resource) { "user" }
+
+      let(:template) do
+        <<~SPEC
+          require 'rails_helper'
+
+          RSpec.describe 'Api::Exposed::V1::BlogsControllers', type: :request do
+          let(:user) { create(:user) }
+
+          describe 'GET /index' do
+          let!(:blogs) { create_list(:blog, 5) }
+          let(:collection) { JSON.parse(response.body)['data'] }
+          let(:params) { {} }
+
+          def perform
+          get '/api/v1/blogs', params: params
+          end
+
+          context 'with authorized user' do
+          before do
+          sign_in(user)
+          perform
+          end
+
+          it { expect(collection.count).to eq(5) }
+          it { expect(response.status).to eq(200) }
+          end
+
+          context 'with unauthorized user' do
+          before { perform }
+
+          it { expect(response.status).to eq(401) }
+          end
+
+          end
+
+          describe 'POST /create' do
+          let(:params) do
+          {
+          blog: {
+          title: 'Some title',
+          body: 'Some body'
+          }
+          }
+          end
+
+          let(:attributes) do
+          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          end
+          def perform
+          post '/api/v1/blogs', params: params
+          end
+
+          context 'with authorized user' do
+          before do
+          sign_in(user)
+          perform
+          end
+
+          it { expect(attributes).to include(params[:blog]) }
+          it { expect(response.status).to eq(201) }
+          context 'with invalid attributes' do
+          let(:params) do
+          {
+          blog: {
+          title: nil}
+          }
+          end
+
+          it { expect(response.status).to eq(400) }
+          end
+
+          end
+
+          context 'with unauthorized user' do
+          before { perform }
+
+          it { expect(response.status).to eq(401) }
+          end
+
+          end
+
+          describe 'GET /show' do
+          let(:blog) { create(:blog) }
+          let(:blog_id) { blog.id.to_s }
+
+          let(:attributes) do
+          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          end
+          def perform
+          get '/api/v1/blogs/' + blog_id
+          end
+
+          context 'with authorized user' do
+          before do
+          sign_in(user)
+          perform
+          end
+
+          it { expect(response.status).to eq(200) }
+          context 'with resource not found' do
+          let(:blog_id) { '666' }
+          it { expect(response.status).to eq(404) }
+          end
+          end
+
+          context 'with unauthorized user' do
+          before { perform }
+
+          it { expect(response.status).to eq(401) }
+          end
+
+          end
+
+          describe 'PUT /update' do
+          let(:blog) { create(:blog) }
+          let(:blog_id) { blog.id.to_s }
+
+          let(:params) do
+          {
+          blog: {
+          title: 'Some title',
+          body: 'Some body'
+          }
+          }
+          end
+
+          let(:attributes) do
+          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          end
+          def perform
+          put '/api/v1/blogs/' + blog_id, params: params
+          end
+
+          context 'with authorized user' do
+          before do
+          sign_in(user)
+          perform
+          end
+
+          it { expect(attributes).to include(params[:blog]) }
+          it { expect(response.status).to eq(200) }
+          context 'with invalid attributes' do
+          let(:params) do
+          {
+          blog: {
+          title: nil}
+          }
+          end
+
+          it { expect(response.status).to eq(400) }
+          end
+
+          context 'with resource not found' do
+          let(:blog_id) { '666' }
+          it { expect(response.status).to eq(404) }
+          end
+          end
+
+          context 'with unauthorized user' do
+          before { perform }
+
+          it { expect(response.status).to eq(401) }
+          end
+
+          end
+
+          describe 'DELETE /destroy' do
+          let(:blog) { create(:blog) }
+          let(:blog_id) { blog.id.to_s }
+
+          def perform
+          get '/api/v1/blogs/' + blog_id
+          end
+
+          context 'with authorized user' do
+          before do
+          sign_in(user)
+          perform
+          end
+
+          it { expect(response.status).to eq(200) }
+          context 'with resource not found' do
+          let(:blog_id) { '666' }
+          it { expect(response.status).to eq(404) }
+          end
+          end
+
+          context 'with unauthorized user' do
+          before { perform }
+
+          it { expect(response.status).to eq(401) }
+          end
+
+          end
+
+          end
+        SPEC
+      end
+
+      it { expect(perform).to eq(template) }
+
+      context "with owned_by_authenticated_resource option" do
+        let(:authenticated_resource) { "user" }
+        let(:owned_by_authenticated_resource) { true }
+
+        it { expect(perform).to include("create_list(:blog, 5, user: user)") }
+      end
+    end
+
+    context "with parent_resource option" do
+      let(:parent_resource_name) { "portfolio" }
+
+      it { expect(perform).to include("let(:portfolio) { create(:portfolio) }") }
+      it { expect(perform).to include("let(:portfolio_id) { portfolio.id }") }
+      it { expect(perform).to include("!(:blogs) { create_list(:blog, 5, portfolio: portfolio) }") }
+      it { expect(perform).to include("v1/portfolios/' + portfolio.id.to_s + '/blogs', params: p") }
+    end
+
+    context 'with only some actions (show and create)' do
+      let(:controller_actions) do
+        [
+          "show",
+          "create"
+        ]
+      end
+
+      it { expect(perform).to include("describe 'GET /show'") }
+      it { expect(perform).to include("describe 'POST /create'") }
+      it { expect(perform).not_to include("describe 'DELETE /destroy'") }
+      it { expect(perform).not_to include("describe 'PUT /update'") }
+      it { expect(perform).not_to include("describe 'GET /index'") }
+    end
+  end
+end

--- a/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
@@ -185,7 +185,6 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
 
           RSpec.describe 'Api::Exposed::V1::BlogsControllers', type: :request do
           let(:user) { create(:user) }
-
           describe 'GET /index' do
           let!(:blogs) { create_list(:blog, 5) }
           let(:collection) { JSON.parse(response.body)['data'] }
@@ -390,10 +389,156 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
     context "with parent_resource option" do
       let(:parent_resource_name) { "portfolio" }
 
-      it { expect(perform).to include("let(:portfolio) { create(:portfolio) }") }
-      it { expect(perform).to include("let(:portfolio_id) { portfolio.id }") }
-      it { expect(perform).to include("!(:blogs) { create_list(:blog, 5, portfolio: portfolio) }") }
-      it { expect(perform).to include("v1/portfolios/' + portfolio.id.to_s + '/blogs', params: p") }
+      let(:template) do
+        <<~SPEC
+          require 'rails_helper'
+
+          RSpec.describe 'Api::Exposed::V1::BlogsControllers', type: :request do
+          let(:portfolio) { create(:portfolio) }
+          let(:portfolio_id) { portfolio.id }
+
+          describe 'GET /index' do
+          let!(:blogs) { create_list(:blog, 5, portfolio: portfolio) }
+          let(:collection) { JSON.parse(response.body)['data'] }
+          let(:params) { {} }
+
+          def perform
+          get '/api/v1/portfolios/' + portfolio.id.to_s + '/blogs', params: params
+          end
+
+          before do
+          perform
+          end
+
+          it { expect(collection.count).to eq(5) }
+          it { expect(response.status).to eq(200) }
+          end
+
+          describe 'POST /create' do
+          let(:params) do
+          {
+          blog: {
+          title: 'Some title',
+          body: 'Some body'
+          }
+          }
+          end
+
+          let(:attributes) do
+          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          end
+          def perform
+          post '/api/v1/portfolios/' + portfolio.id.to_s + '/blogs', params: params
+          end
+
+          before do
+          perform
+          end
+
+          it { expect(attributes).to include(params[:blog]) }
+          it { expect(response.status).to eq(201) }
+          context 'with invalid attributes' do
+          let(:params) do
+          {
+          blog: {
+          title: nil}
+          }
+          end
+
+          it { expect(response.status).to eq(400) }
+          end
+
+          end
+
+          describe 'GET /show' do
+          let(:blog) { create(:blog, portfolio: portfolio) }
+          let(:blog_id) { blog.id.to_s }
+
+          let(:attributes) do
+          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          end
+          def perform
+          get '/api/v1/blogs/' + blog_id
+          end
+
+          before do
+          perform
+          end
+
+          it { expect(response.status).to eq(200) }
+          context 'with resource not found' do
+          let(:blog_id) { '666' }
+          it { expect(response.status).to eq(404) }
+          end
+          end
+
+          describe 'PUT /update' do
+          let(:blog) { create(:blog, portfolio: portfolio) }
+          let(:blog_id) { blog.id.to_s }
+
+          let(:params) do
+          {
+          blog: {
+          title: 'Some title',
+          body: 'Some body'
+          }
+          }
+          end
+
+          let(:attributes) do
+          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          end
+          def perform
+          put '/api/v1/blogs/' + blog_id, params: params
+          end
+
+          before do
+          perform
+          end
+
+          it { expect(attributes).to include(params[:blog]) }
+          it { expect(response.status).to eq(200) }
+          context 'with invalid attributes' do
+          let(:params) do
+          {
+          blog: {
+          title: nil}
+          }
+          end
+
+          it { expect(response.status).to eq(400) }
+          end
+
+          context 'with resource not found' do
+          let(:blog_id) { '666' }
+          it { expect(response.status).to eq(404) }
+          end
+          end
+
+          describe 'DELETE /destroy' do
+          let(:blog) { create(:blog, portfolio: portfolio) }
+          let(:blog_id) { blog.id.to_s }
+
+          def perform
+          get '/api/v1/blogs/' + blog_id
+          end
+
+          before do
+          perform
+          end
+
+          it { expect(response.status).to eq(200) }
+          context 'with resource not found' do
+          let(:blog_id) { '666' }
+          it { expect(response.status).to eq(404) }
+          end
+          end
+
+          end
+        SPEC
+      end
+
+      it { expect(perform).to eq(template) }
     end
 
     context 'with only some actions (show and create)' do


### PR DESCRIPTION
- Now installer just install basic stuff.
- Add `power_api:exposed_api_config` to configure API exposed mode.
- Add `power_api:internal_api_config` to configure API internal mode.
- Change `power_api:controller` to play nice with both modes.
- Generate request specs for internal API controllers.

Check the README for further details: https://github.com/platanus/power_api/blob/41cf058b7c7b31058e67d48eef08dd055c96827a/README.md