### PR TITLE
json_api adapter replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,8 @@ After doing this you will get:
 - Some initializers:
   - `/your_api/config/initializers/active_model_serializers.rb`:
     ```ruby
-    class ActiveModelSerializers::Adapter::JsonApi
-      def self.default_key_transform
-        :unaltered
-      end
-    end
-
-    ActiveModelSerializers.config.adapter = :json_api
+    ActiveModelSerializers.config.adapter = :json
     ```
-    Here we tell AMS that we will use the [json api](https://jsonapi.org/) format.
 
   - `/your_api/config/initializers/api_pagination.rb`:
     ```ruby
@@ -410,7 +403,7 @@ after doing this you will get:
           schema('$ref' => '#/definitions/blogs_collection')
 
           run_test! do |response|
-            expect(JSON.parse(response.body)['data'].count).to eq(expected_collection_count)
+            expect(JSON.parse(response.body)['blogs'].count).to eq(expected_collection_count)
           end
         end
       end
@@ -421,11 +414,21 @@ after doing this you will get:
         produces 'application/json'
         parameter(name: :blog, in: :body)
 
-        response '201', 'blog creaed' do
+        response '201', 'blog created' do
           let(:blog) do
             {
               title: 'Some title',
               body: 'Some body'
+            }
+          end
+
+          run_test!
+        end
+
+        response '400', 'invalid attributes' do
+          let(:blog) do
+            {
+              title: nil
             }
           end
 
@@ -471,6 +474,16 @@ after doing this you will get:
 
           run_test!
         end
+
+        response '400', 'invalid attributes' do
+          let(:blog) do
+            {
+              title: nil
+            }
+          end
+
+          run_test!
+        end
       end
 
       delete 'Deletes Blog' do
@@ -489,15 +502,16 @@ after doing this you will get:
       end
     end
   end
+
   ```
   - Internal mode:
   ```ruby
   require 'rails_helper'
 
-  RSpec.describe 'Api::Internal::BlogsControllers', type: :request do
+  describe 'Api::Internal::BlogsControllers', type: :request do
     describe 'GET /index' do
       let!(:blogs) { create_list(:blog, 5) }
-      let(:collection) { JSON.parse(response.body)['data'] }
+      let(:collection) { JSON.parse(response.body)['blogs'] }
       let(:params) { {} }
 
       def perform
@@ -522,7 +536,7 @@ after doing this you will get:
       end
 
       let(:attributes) do
-        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        JSON.parse(response.body).symbolize_keys
       end
 
       def perform
@@ -554,7 +568,7 @@ after doing this you will get:
       let(:blog_id) { blog.id.to_s }
 
       let(:attributes) do
-        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        JSON.parse(response.body)['blog'].symbolize_keys
       end
 
       def perform
@@ -587,7 +601,7 @@ after doing this you will get:
       end
 
       let(:attributes) do
-        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        JSON.parse(response.body)['blog'].symbolize_keys
       end
 
       def perform
@@ -648,47 +662,38 @@ after doing this you will get:
   BLOG_SCHEMA = {
     type: :object,
     properties: {
-      id: { type: :string, example: '1' },
-      type: { type: :string, example: 'blog' },
-      attributes: {
-        type: :object,
-        properties: {
-          title: { type: :string, example: 'Some title', 'x-nullable': true },
-          body: { type: :string, example: 'Some body', 'x-nullable': true },
-          created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
-          updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
-        },
-        required: [
-        ]
-      }
+      title: { type: :string, example: 'Some title' },
+      body: { type: :string, example: 'Some body' },
+      created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
+      updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
+      portfolio_id: { type: :integer, example: 666, 'x-nullable': true }
     },
     required: [
-      :id,
-      :type,
-      :attributes
+      :title,
+      :body
     ]
   }
 
   BLOGS_COLLECTION_SCHEMA = {
     type: "object",
     properties: {
-      data: {
+      blogs: {
         type: "array",
         items: { "$ref" => "#/definitions/blog" }
       }
     },
     required: [
-      :data
+      :blogs
     ]
   }
 
   BLOG_RESOURCE_SCHEMA = {
     type: "object",
     properties: {
-      data: { "$ref" => "#/definitions/blog" }
+      blog: { "$ref" => "#/definitions/blog" }
     },
     required: [
-      :data
+      :blog
     ]
   }
   ```
@@ -745,7 +750,7 @@ When you do this, you will see that only relevant code is generated in controlle
 For example, the controller would only include the `show` and `destroy` actions and wouldn't include the `blog_params` method:
 
 ```ruby
-class Api::Exposed::V1::BlogSerializer < Api::Exposed::V1::BaseController
+class Api::Exposed::V1::BlogController < Api::Exposed::V1::BaseController
   def show
     respond_with blog
   end

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ after doing this you will get:
 
     def blog_params
       params.require(:blog).permit(
+        :id,
         :title,
         :body,
       )
@@ -374,6 +375,7 @@ after doing this you will get:
     type :blog
 
     attributes(
+      :id,
       :title,
       :body,
       :created_at,
@@ -662,6 +664,7 @@ after doing this you will get:
   BLOG_SCHEMA = {
     type: :object,
     properties: {
+      id: { type: :integer, example: 666 },
       title: { type: :string, example: 'Some title' },
       body: { type: :string, example: 'Some body' },
       created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
@@ -914,6 +917,7 @@ class Api::Exposed::V1::BlogsController < Api::Exposed::V1::BaseController
 
   def blog_params
     params.require(:blog).permit(
+      :id,
       :title,
       :body
     )
@@ -996,6 +1000,7 @@ Running the previous code we will get:
 
     def comment_params
       params.require(:comment).permit(
+        :id,
         :body
       )
     end

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ after doing this you will get:
       end
 
       let(:attributes) do
-        JSON.parse(response.body).symbolize_keys
+        JSON.parse(response.body)['blog'].symbolize_keys
       end
 
       def perform

--- a/lib/power_api/generator_helper/ams_helper.rb
+++ b/lib/power_api/generator_helper/ams_helper.rb
@@ -20,13 +20,7 @@ module PowerApi::GeneratorHelper::AmsHelper
 
   def ams_initializer_tpl
     <<~INITIALIZER
-      class ActiveModelSerializers::Adapter::JsonApi
-        def self.default_key_transform
-          :unaltered
-        end
-      end
-
-      ActiveModelSerializers.config.adapter = :json_api
+      ActiveModelSerializers.config.adapter = :json
     INITIALIZER
   end
 

--- a/lib/power_api/generator_helper/controller_helper.rb
+++ b/lib/power_api/generator_helper/controller_helper.rb
@@ -43,6 +43,7 @@ module PowerApi::GeneratorHelper::ControllerHelper
   def exposed_base_controller_tpl
     <<~CONTROLLER
       class #{exposed_class}::BaseController < Api::BaseController
+        skip_before_action :verify_authenticity_token
       end
     CONTROLLER
   end

--- a/lib/power_api/generator_helper/rspec_controller_helper.rb
+++ b/lib/power_api/generator_helper/rspec_controller_helper.rb
@@ -59,7 +59,7 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
     concat_tpl_statements(
       "describe 'GET /index' do",
         "let!(:#{resource.plural}) { #{spec_index_creation_list_tpl} }",
-        "let(:collection) { JSON.parse(response.body)['data'] }",
+        "let(:collection) { JSON.parse(response.body)['#{resource.plural}'] }",
         "let(:params) { {} }\n",
         spec_perform_tpl,
         with_authorized_resource_context,
@@ -209,7 +209,7 @@ module PowerApi::GeneratorHelper::RspecControllerHelper
   def let_resource_attrs
     concat_tpl_statements(
       "let(:attributes) do",
-        "JSON.parse(response.body)['data']['attributes'].symbolize_keys",
+        "JSON.parse(response.body)['#{resource.snake_case}'].symbolize_keys",
       "end"
     )
   end

--- a/lib/power_api/generator_helper/swagger_helper.rb
+++ b/lib/power_api/generator_helper/swagger_helper.rb
@@ -118,44 +118,32 @@ module PowerApi::GeneratorHelper::SwaggerHelper
     <<~SCHEMA
       #{swagger_model_definition_const} = {
         type: :object,
-        properties: {
-          id: { type: :string, example: '1' },
-          type: { type: :string, example: '#{resource.snake_case}' },
-          attributes: {
-            type: :object,
-            properties: {#{get_swagger_schema_attributes_definitions}
-            },
-            required: [#{get_swagger_schema_attributes_names}
-            ]
-          }
+        properties: {#{get_swagger_schema_attributes_definitions}
         },
-        required: [
-          :id,
-          :type,
-          :attributes
+        required: [#{get_swagger_schema_attributes_names}
         ]
       }
 
       #{swagger_collection_definition_const} = {
         type: "object",
         properties: {
-          data: {
+          #{resource.plural}: {
             type: "array",
             items: { "$ref" => "#/definitions/#{resource.snake_case}" }
           }
         },
         required: [
-          :data
+          :#{resource.plural}
         ]
       }
 
       #{swagger_resource_definition_const} = {
         type: "object",
         properties: {
-          data: { "$ref" => "#/definitions/#{resource.snake_case}" }
+          #{resource.snake_case}: { "$ref" => "#/definitions/#{resource.snake_case}" }
         },
         required: [
-          :data
+          :#{resource.snake_case}
         ]
       }
     SCHEMA
@@ -268,7 +256,7 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
         "response '200', '#{resource.plural_titleized} retrieved' do",
           "schema('$ref' => '#/definitions/#{resource.plural}_collection')\n",
           "run_test! do |response|",
-            "expect(JSON.parse(response.body)['data'].count).to eq(expected_collection_count)",
+            "expect(JSON.parse(response.body)['#{resource.plural}'].count).to eq(expected_collection_count)",
           "end",
         "end\n",
         spec_tpl_invalid_credentials,

--- a/lib/power_api/generator_helper/swagger_helper.rb
+++ b/lib/power_api/generator_helper/swagger_helper.rb
@@ -440,7 +440,7 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   def get_swagger_schema_attributes_definitions
     for_each_schema_attribute(resource.resource_attributes) do |attr|
       opts = ["example: #{attr[:example]}"]
-      opts << "'x-nullable': true" unless attr[:required]
+      opts << "'x-nullable': true" unless attr[:required] || attr[:name] == :id
       opts
 
       "#{attr[:name]}: { type: :#{attr[:swagger_type]}, #{opts.join(', ')} },"
@@ -448,7 +448,9 @@ swagger_doc: 'v#{version_number}/swagger.json' do"
   end
 
   def get_swagger_schema_attributes_names
-    for_each_schema_attribute(resource.required_resource_attributes) do |attr|
+    for_each_schema_attribute(
+      resource.required_resource_attributes(include_id: true)
+    ) do |attr|
       ":#{attr[:name]},"
     end
   end

--- a/spec/dummy/spec/lib/power_api/generator_helper/ams_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/ams_helper_spec.rb
@@ -64,13 +64,7 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
   describe "ams_initializer_tpl" do
     let(:template) do
       <<~INITIALIZER
-        class ActiveModelSerializers::Adapter::JsonApi
-          def self.default_key_transform
-            :unaltered
-          end
-        end
-
-        ActiveModelSerializers.config.adapter = :json_api
+        ActiveModelSerializers.config.adapter = :json
       INITIALIZER
     end
 

--- a/spec/dummy/spec/lib/power_api/generator_helper/ams_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/ams_helper_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
           type :blog
 
           attributes(
-            :title,
+            :id,
+        :title,
         :body,
         :created_at,
         :updated_at,
@@ -107,7 +108,8 @@ RSpec.describe PowerApi::GeneratorHelper::AmsHelper, type: :generator do
             type :blog
 
             attributes(
-              :title,
+              :id,
+          :title,
           :body,
           :created_at,
           :updated_at,

--- a/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
     let(:template) do
       <<~CONTROLLER
         class Api::Exposed::BaseController < Api::BaseController
+          skip_before_action :verify_authenticity_token
         end
       CONTROLLER
     end

--- a/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/controller_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
+describe PowerApi::GeneratorHelper::ControllerHelper, type: :generator do
   describe "#api_main_base_controller_path" do
     let(:expected_path) { "app/controllers/api/base_controller.rb" }
 

--- a/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/rspec_controller_helper_spec.rb
@@ -24,7 +24,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
         RSpec.describe 'Api::Exposed::V1::BlogsControllers', type: :request do
         describe 'GET /index' do
         let!(:blogs) { create_list(:blog, 5) }
-        let(:collection) { JSON.parse(response.body)['data'] }
+        let(:collection) { JSON.parse(response.body)['blogs'] }
         let(:params) { {} }
 
         def perform
@@ -50,7 +50,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
         end
 
         let(:attributes) do
-        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        JSON.parse(response.body)['blog'].symbolize_keys
         end
         def perform
         post '/api/v1/blogs', params: params
@@ -80,7 +80,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
         let(:blog_id) { blog.id.to_s }
 
         let(:attributes) do
-        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        JSON.parse(response.body)['blog'].symbolize_keys
         end
         def perform
         get '/api/v1/blogs/' + blog_id
@@ -111,7 +111,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
         end
 
         let(:attributes) do
-        JSON.parse(response.body)['data']['attributes'].symbolize_keys
+        JSON.parse(response.body)['blog'].symbolize_keys
         end
         def perform
         put '/api/v1/blogs/' + blog_id, params: params
@@ -187,7 +187,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           let(:user) { create(:user) }
           describe 'GET /index' do
           let!(:blogs) { create_list(:blog, 5) }
-          let(:collection) { JSON.parse(response.body)['data'] }
+          let(:collection) { JSON.parse(response.body)['blogs'] }
           let(:params) { {} }
 
           def perform
@@ -223,7 +223,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           end
 
           let(:attributes) do
-          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          JSON.parse(response.body)['blog'].symbolize_keys
           end
           def perform
           post '/api/v1/blogs', params: params
@@ -263,7 +263,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           let(:blog_id) { blog.id.to_s }
 
           let(:attributes) do
-          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          JSON.parse(response.body)['blog'].symbolize_keys
           end
           def perform
           get '/api/v1/blogs/' + blog_id
@@ -304,7 +304,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           end
 
           let(:attributes) do
-          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          JSON.parse(response.body)['blog'].symbolize_keys
           end
           def perform
           put '/api/v1/blogs/' + blog_id, params: params
@@ -399,7 +399,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
 
           describe 'GET /index' do
           let!(:blogs) { create_list(:blog, 5, portfolio: portfolio) }
-          let(:collection) { JSON.parse(response.body)['data'] }
+          let(:collection) { JSON.parse(response.body)['blogs'] }
           let(:params) { {} }
 
           def perform
@@ -425,7 +425,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           end
 
           let(:attributes) do
-          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          JSON.parse(response.body)['blog'].symbolize_keys
           end
           def perform
           post '/api/v1/portfolios/' + portfolio.id.to_s + '/blogs', params: params
@@ -455,7 +455,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           let(:blog_id) { blog.id.to_s }
 
           let(:attributes) do
-          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          JSON.parse(response.body)['blog'].symbolize_keys
           end
           def perform
           get '/api/v1/blogs/' + blog_id
@@ -486,7 +486,7 @@ describe PowerApi::GeneratorHelper::RspecControllerHelper, type: :generator do
           end
 
           let(:attributes) do
-          JSON.parse(response.body)['data']['attributes'].symbolize_keys
+          JSON.parse(response.body)['blog'].symbolize_keys
           end
           def perform
           put '/api/v1/blogs/' + blog_id, params: params

--- a/spec/dummy/spec/lib/power_api/generator_helper/swagger_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/swagger_helper_spec.rb
@@ -206,50 +206,38 @@ RSpec.describe PowerApi::GeneratorHelper::SwaggerHelper, type: :generator do
         BLOG_SCHEMA = {
           type: :object,
           properties: {
-            id: { type: :string, example: '1' },
-            type: { type: :string, example: 'blog' },
-            attributes: {
-              type: :object,
-              properties: {
         title: { type: :string, example: 'Some title' },
         body: { type: :string, example: 'Some body' },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
         updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
         portfolio_id: { type: :integer, example: 666, 'x-nullable': true }
-              },
-              required: [
-        :title,
-        :body
-              ]
-            }
           },
           required: [
-            :id,
-            :type,
-            :attributes
+        :title,
+        :body
           ]
         }
 
         BLOGS_COLLECTION_SCHEMA = {
           type: "object",
           properties: {
-            data: {
+            blogs: {
               type: "array",
               items: { "$ref" => "#/definitions/blog" }
             }
           },
           required: [
-            :data
+            :blogs
           ]
         }
 
         BLOG_RESOURCE_SCHEMA = {
           type: "object",
           properties: {
-            data: { "$ref" => "#/definitions/blog" }
+            blog: { "$ref" => "#/definitions/blog" }
           },
           required: [
-            :data
+            :blog
           ]
         }
       SCHEMA
@@ -281,7 +269,7 @@ RSpec.describe PowerApi::GeneratorHelper::SwaggerHelper, type: :generator do
         schema('$ref' => '#/definitions/blogs_collection')
 
         run_test! do |response|
-        expect(JSON.parse(response.body)['data'].count).to eq(expected_collection_count)
+        expect(JSON.parse(response.body)['blogs'].count).to eq(expected_collection_count)
         end
         end
 

--- a/spec/dummy/spec/lib/power_api/generator_helper/swagger_helper_spec.rb
+++ b/spec/dummy/spec/lib/power_api/generator_helper/swagger_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PowerApi::GeneratorHelper::SwaggerHelper, type: :generator do
+describe PowerApi::GeneratorHelper::SwaggerHelper, type: :generator do
   describe "#swagger_helper_path" do
     let(:expected_path) { "spec/swagger_helper.rb" }
 
@@ -206,6 +206,7 @@ RSpec.describe PowerApi::GeneratorHelper::SwaggerHelper, type: :generator do
         BLOG_SCHEMA = {
           type: :object,
           properties: {
+        id: { type: :integer, example: 666 },
         title: { type: :string, example: 'Some title' },
         body: { type: :string, example: 'Some body' },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
@@ -213,6 +214,7 @@ RSpec.describe PowerApi::GeneratorHelper::SwaggerHelper, type: :generator do
         portfolio_id: { type: :integer, example: 666, 'x-nullable': true }
           },
           required: [
+        :id,
         :title,
         :body
           ]

--- a/spec/dummy/spec/support/shared_examples/active_record_resource_atrributes.rb
+++ b/spec/dummy/spec/support/shared_examples/active_record_resource_atrributes.rb
@@ -68,6 +68,8 @@ shared_examples 'ActiveRecord resource attributes' do |attributes_key|
           { name: :body, type: :text, swagger_type: :string, example: "'Some body'", required: true }
         ]
       end
+
+      it { expect(perform).to match(expected_attributes) }
     end
   end
 

--- a/spec/dummy/spec/support/shared_examples/active_record_resource_atrributes.rb
+++ b/spec/dummy/spec/support/shared_examples/active_record_resource_atrributes.rb
@@ -3,6 +3,7 @@ shared_examples 'ActiveRecord resource attributes' do |attributes_key|
   describe "#resource_attributes" do
     let(:expected_attributes) do
       [
+        { name: :id, type: :integer, swagger_type: :integer, example: kind_of(Integer), required: false },
         { name: :title, type: :string, swagger_type: :string, example: "'Some title'", required: true },
         { name: :body, type: :text, swagger_type: :string, example: "'Some body'", required: true },
         { name: :created_at, type: :datetime, swagger_type: :string, example: "'1984-06-04 09:00'", required: false },
@@ -21,27 +22,30 @@ shared_examples 'ActiveRecord resource attributes' do |attributes_key|
       let(attributes_key) { %w{title body} }
       let(:expected_attributes) do
         [
+          { name: :id, type: :integer, swagger_type: :integer, example: kind_of(Integer), required: false },
           { name: :title, type: :string, swagger_type: :string, example: "'Some title'", required: true },
           { name: :body, type: :text, swagger_type: :string, example: "'Some body'", required: true }
         ]
       end
 
-      it { expect(perform).to eq(expected_attributes) }
+      it { expect(perform).to match(expected_attributes) }
     end
 
     context "with attributes not present in model" do
       let(attributes_key) { %w{title bloody} }
       let(:expected_attributes) do
         [
+          { name: :id, type: :integer, swagger_type: :integer, example: kind_of(Integer), required: false },
           { name: :title, type: :string, swagger_type: :string, example: "'Some title'", required: true }
         ]
       end
 
-      it { expect(perform).to eq(expected_attributes) }
+      it { expect(perform).to match(expected_attributes) }
     end
   end
 
   describe "#required_resource_attributes" do
+    let(:include_id) { false }
     let(:expected_attributes) do
       [
         { name: :title, type: :string, swagger_type: :string, example: "'Some title'", required: true },
@@ -50,10 +54,21 @@ shared_examples 'ActiveRecord resource attributes' do |attributes_key|
     end
 
     def perform
-      resource.required_resource_attributes
+      resource.required_resource_attributes(include_id: include_id)
     end
 
     it { expect(perform).to eq(expected_attributes) }
+
+    context "with included id" do
+      let(:include_id) { true }
+      let(:expected_attributes) do
+        [
+          { name: :id, type: :integer, swagger_type: :integer, example: kind_of(Integer), required: false },
+          { name: :title, type: :string, swagger_type: :string, example: "'Some title'", required: true },
+          { name: :body, type: :text, swagger_type: :string, example: "'Some body'", required: true }
+        ]
+      end
+    end
   end
 
   describe "#required_attributes_names" do
@@ -88,6 +103,7 @@ shared_examples 'ActiveRecord resource attributes' do |attributes_key|
   describe "#attributes_names" do
     let(:expected_attributes) do
       [
+        :id,
         :title,
         :body,
         :created_at,
@@ -138,6 +154,7 @@ shared_examples 'ActiveRecord resource attributes' do |attributes_key|
   describe "#attributes_symbols_text_list" do
     let(:expected_result) do
       <<~ATTRS
+        :id,
         :title,
         :body,
         :created_at,


### PR DESCRIPTION
Use `:json` instead of `:json_api` adpater

Collection example:

![image](https://user-images.githubusercontent.com/3026413/151247729-1fc87835-dcbe-484f-91b4-6facb88453d8.png)

Resource example:

![image](https://user-images.githubusercontent.com/3026413/151247824-69c08289-885d-4518-9a47-87b70d4bd704.png)

